### PR TITLE
Migrate getPrice to L2 ETH Registrar

### DIFF
--- a/packages/ensjs/src/actions/public/getPrice.ts
+++ b/packages/ensjs/src/actions/public/getPrice.ts
@@ -1,38 +1,38 @@
 import type {
-	Chain,
-	GetChainContractAddressErrorType,
-	ReadContractErrorType,
-} from "viem";
-import { readContract } from "viem/actions";
-import { getAction } from "viem/utils";
+  Chain,
+  GetChainContractAddressErrorType,
+  ReadContractErrorType,
+} from 'viem'
+import { readContract } from 'viem/actions'
+import { getAction } from 'viem/utils'
 import {
-	getChainContractAddress,
-	type RequireClientContracts,
-} from "../../clients/chain.js";
-import { l2EthRegistrarRentPriceSnippet } from "../../contracts/l2EthRegistrar.js";
-import { UnsupportedNameTypeError } from "../../errors/general.js";
-import { ASSERT_NO_TYPE_ERROR } from "../../types/internal.js";
-import { getNameType } from "../../utils/name/getNameType.js";
+  getChainContractAddress,
+  type RequireClientContracts,
+} from '../../clients/chain.js'
+import { l2EthRegistrarRentPriceSnippet } from '../../contracts/l2EthRegistrar.js'
+import { UnsupportedNameTypeError } from '../../errors/general.js'
+import { ASSERT_NO_TYPE_ERROR } from '../../types/internal.js'
+import { getNameType } from '../../utils/name/getNameType.js'
 
 export type GetPriceParameters = {
-	/** Name, or array of names, to get price for */
-	nameOrNames: string | string[];
-	/** Duration in seconds to get price for */
-	duration: bigint | number;
-};
+  /** Name, or array of names, to get price for */
+  nameOrNames: string | string[]
+  /** Duration in seconds to get price for */
+  duration: bigint | number
+}
 
 export type GetPriceReturnType = {
-	/** Price base value */
-	base: bigint;
-	/** Price premium */
-	premium: bigint;
-};
+  /** Price base value */
+  base: bigint
+  /** Price premium */
+  premium: bigint
+}
 
 export type GetPriceErrorType =
-	| UnsupportedNameTypeError
-	| GetChainContractAddressErrorType
-	| ReadContractErrorType
-	| TypeError;
+  | UnsupportedNameTypeError
+  | GetChainContractAddressErrorType
+  | ReadContractErrorType
+  | TypeError
 
 /**
  * Gets the price of a name, or array of names, for a given duration.
@@ -54,47 +54,47 @@ export type GetPriceErrorType =
  * // { base: 352828971668930335n, premium: 0n }
  */
 export async function getPrice<chain extends Chain>(
-	client: RequireClientContracts<chain, "ensL2EthRegistrar">,
-	{ nameOrNames, duration }: GetPriceParameters,
+  client: RequireClientContracts<chain, 'ensL2EthRegistrar'>,
+  { nameOrNames, duration }: GetPriceParameters,
 ): Promise<GetPriceReturnType> {
-	ASSERT_NO_TYPE_ERROR(client);
+  ASSERT_NO_TYPE_ERROR(client)
 
-	const names = Array.isArray(nameOrNames) ? nameOrNames : [nameOrNames];
+  const names = Array.isArray(nameOrNames) ? nameOrNames : [nameOrNames]
 
-	let totalBase = 0n;
-	let totalPremium = 0n;
+  let totalBase = 0n
+  let totalPremium = 0n
 
-	const readContractAction = getAction(client, readContract, "readContract");
+  const readContractAction = getAction(client, readContract, 'readContract')
 
-	// Process each name individually and aggregate the results
-	// TODO: not sure if this is the best way to do this, ask Jakob
-	for (const name of names) {
-		const labels = name.split(".");
-		const nameType = getNameType(name);
+  // Process each name individually and aggregate the results
+  // TODO: not sure if this is the best way to do this, ask Jakob
+  for (const name of names) {
+    const labels = name.split('.')
+    const nameType = getNameType(name)
 
-		if (nameType !== "eth-2ld" && nameType !== "tld")
-			throw new UnsupportedNameTypeError({
-				nameType,
-				supportedNameTypes: ["eth-2ld", "tld"],
-				details: "Currently only the price of eth-2ld names can be fetched",
-			});
+    if (nameType !== 'eth-2ld' && nameType !== 'tld')
+      throw new UnsupportedNameTypeError({
+        nameType,
+        supportedNameTypes: ['eth-2ld', 'tld'],
+        details: 'Currently only the price of eth-2ld names can be fetched',
+      })
 
-		const result = await readContractAction({
-			address: getChainContractAddress({
-				chain: client.chain,
-				contract: "ensL2EthRegistrar",
-			}),
-			abi: l2EthRegistrarRentPriceSnippet,
-			functionName: "rentPrice",
-			args: [labels[0], BigInt(duration)],
-		});
+    const result = await readContractAction({
+      address: getChainContractAddress({
+        chain: client.chain,
+        contract: 'ensL2EthRegistrar',
+      }),
+      abi: l2EthRegistrarRentPriceSnippet,
+      functionName: 'rentPrice',
+      args: [labels[0], BigInt(duration)],
+    })
 
-		totalBase += result.base;
-		totalPremium += result.premium;
-	}
+    totalBase += result.base
+    totalPremium += result.premium
+  }
 
-	return {
-		base: totalBase,
-		premium: totalPremium,
-	};
+  return {
+    base: totalBase,
+    premium: totalPremium,
+  }
 }

--- a/packages/ensjs/src/actions/public/getPrice.ts
+++ b/packages/ensjs/src/actions/public/getPrice.ts
@@ -1,38 +1,38 @@
 import type {
-  Chain,
-  GetChainContractAddressErrorType,
-  ReadContractErrorType,
-} from 'viem'
-import { readContract } from 'viem/actions'
-import { getAction } from 'viem/utils'
+	Chain,
+	GetChainContractAddressErrorType,
+	ReadContractErrorType,
+} from "viem";
+import { readContract } from "viem/actions";
+import { getAction } from "viem/utils";
 import {
-  getChainContractAddress,
-  type RequireClientContracts,
-} from '../../clients/chain.js'
-import { l2EthRegistrarRentPriceSnippet } from '../../contracts/l2EthRegistrar.js'
-import { UnsupportedNameTypeError } from '../../errors/general.js'
-import { ASSERT_NO_TYPE_ERROR } from '../../types/internal.js'
-import { getNameType } from '../../utils/name/getNameType.js'
+	getChainContractAddress,
+	type RequireClientContracts,
+} from "../../clients/chain.js";
+import { l2EthRegistrarRentPriceSnippet } from "../../contracts/l2EthRegistrar.js";
+import { UnsupportedNameTypeError } from "../../errors/general.js";
+import { ASSERT_NO_TYPE_ERROR } from "../../types/internal.js";
+import { getNameType } from "../../utils/name/getNameType.js";
 
 export type GetPriceParameters = {
-  /** Name, or array of names, to get price for */
-  nameOrNames: string | string[]
-  /** Duration in seconds to get price for */
-  duration: bigint | number
-}
+	/** Name, or array of names, to get price for */
+	nameOrNames: string | string[];
+	/** Duration in seconds to get price for */
+	duration: bigint | number;
+};
 
 export type GetPriceReturnType = {
-  /** Price base value */
-  base: bigint
-  /** Price premium */
-  premium: bigint
-}
+	/** Price base value */
+	base: bigint;
+	/** Price premium */
+	premium: bigint;
+};
 
 export type GetPriceErrorType =
-  | UnsupportedNameTypeError
-  | GetChainContractAddressErrorType
-  | ReadContractErrorType
-  | TypeError
+	| UnsupportedNameTypeError
+	| GetChainContractAddressErrorType
+	| ReadContractErrorType
+	| TypeError;
 
 /**
  * Gets the price of a name, or array of names, for a given duration.
@@ -54,46 +54,47 @@ export type GetPriceErrorType =
  * // { base: 352828971668930335n, premium: 0n }
  */
 export async function getPrice<chain extends Chain>(
-  client: RequireClientContracts<chain, 'ensL2EthRegistrar'>,
-  { nameOrNames, duration }: GetPriceParameters,
+	client: RequireClientContracts<chain, "ensL2EthRegistrar">,
+	{ nameOrNames, duration }: GetPriceParameters,
 ): Promise<GetPriceReturnType> {
-  ASSERT_NO_TYPE_ERROR(client)
+	ASSERT_NO_TYPE_ERROR(client);
 
-  const names = Array.isArray(nameOrNames) ? nameOrNames : [nameOrNames]
-  
-  let totalBase = 0n
-  let totalPremium = 0n
-  
-  const readContractAction = getAction(client, readContract, 'readContract')
-  
-  // Process each name individually and aggregate the results
-  for (const name of names) {
-    const labels = name.split('.')
-    const nameType = getNameType(name)
-    
-    if (nameType !== 'eth-2ld' && nameType !== 'tld')
-      throw new UnsupportedNameTypeError({
-        nameType,
-        supportedNameTypes: ['eth-2ld', 'tld'],
-        details: 'Currently only the price of eth-2ld names can be fetched',
-      })
+	const names = Array.isArray(nameOrNames) ? nameOrNames : [nameOrNames];
 
-    const result = await readContractAction({
-      address: getChainContractAddress({
-        chain: client.chain,
-        contract: 'ensL2EthRegistrar',
-      }),
-      abi: l2EthRegistrarRentPriceSnippet,
-      functionName: 'rentPrice',
-      args: [labels[0], BigInt(duration)],
-    })
-    
-    totalBase += result.base
-    totalPremium += result.premium
-  }
-  
-  return {
-    base: totalBase,
-    premium: totalPremium,
-  }
+	let totalBase = 0n;
+	let totalPremium = 0n;
+
+	const readContractAction = getAction(client, readContract, "readContract");
+
+	// Process each name individually and aggregate the results
+	// TODO: not sure if this is the best way to do this, ask Jakob
+	for (const name of names) {
+		const labels = name.split(".");
+		const nameType = getNameType(name);
+
+		if (nameType !== "eth-2ld" && nameType !== "tld")
+			throw new UnsupportedNameTypeError({
+				nameType,
+				supportedNameTypes: ["eth-2ld", "tld"],
+				details: "Currently only the price of eth-2ld names can be fetched",
+			});
+
+		const result = await readContractAction({
+			address: getChainContractAddress({
+				chain: client.chain,
+				contract: "ensL2EthRegistrar",
+			}),
+			abi: l2EthRegistrarRentPriceSnippet,
+			functionName: "rentPrice",
+			args: [labels[0], BigInt(duration)],
+		});
+
+		totalBase += result.base;
+		totalPremium += result.premium;
+	}
+
+	return {
+		base: totalBase,
+		premium: totalPremium,
+	};
 }

--- a/packages/ensjs/src/test/addTestContracts.ts
+++ b/packages/ensjs/src/test/addTestContracts.ts
@@ -67,6 +67,9 @@ export const localhost = {
     ensEthRegistrarController: {
       address: deploymentAddresses.ETHRegistrarController,
     },
+    ensL2EthRegistrar: {
+      address: deploymentAddresses.ETHRegistrarController,
+    },
     ensNameWrapper: {
       address: deploymentAddresses.NameWrapper,
     },


### PR DESCRIPTION
## Summary
Updated `getPrice` function to use the new L2 ETH registrar, removing legacy functionality as per the migration to namechain.

## Changes Made

### Contract Migration
- **Replaced**: `ensEthRegistrarController` → `ensL2EthRegistrar`
- **Updated ABI**: `ethRegistrarControllerRentPriceSnippet` → `l2EthRegistrarRentPriceSnippet`

### Simplified Implementation
- **Removed**: Bulk renewal functionality (`ensBulkRenewal` contract)
- **Removed**: Complex multicall logic for multiple names
- **Maintained**: Array support through individual L2 registrar calls with result aggregation

### API Compatibility
- ✅ Same function signature: `nameOrNames: string | string[]`
- ✅ Same return type: `{ base: bigint, premium: bigint }`
- ✅ Multiple names still supported (processed sequentially)

### Test Updates
- **Added**: `ensL2EthRegistrar` contract to test localhost chain
- **Reused**: Existing test cases pass without modification

## Migration Pattern
Follows the same L2 migration pattern as `commitName` and `registerName`:
- Replace legacy ETH registrar controller with L2 ETH registrar
- Remove complex legacy features not needed for L2
- Maintain backward compatibility at the API level

PS. Im not sure if removing the bulkRenewal was part of the "legacy not needed"