### PR TITLE
adds new renew method for l2

### DIFF
--- a/packages/ensjs/src/actions/wallet/renewNames.test.ts
+++ b/packages/ensjs/src/actions/wallet/renewNames.test.ts
@@ -1,93 +1,79 @@
-import { type Address, type Hex, labelhash } from 'viem'
-import { afterEach, beforeAll, beforeEach, expect, it } from 'vitest'
-import { baseRegistrarNameExpiresSnippet } from '../../contracts/baseRegistrar.js'
-import { getChainContractAddress } from '../../contracts/getChainContractAddress.js'
+import { type Address, type Hex, labelhash } from "viem";
+import { afterEach, beforeAll, beforeEach, expect, it } from "vitest";
+import { baseRegistrarNameExpiresSnippet } from "../../contracts/baseRegistrar.js";
+import { getChainContractAddress } from "../../contracts/getChainContractAddress.js";
 import {
-  publicClient,
-  testClient,
-  waitForTransaction,
-  walletClient,
-} from '../../test/addTestContracts.js'
-import { getPrice } from '../public/getPrice.js'
-import { renewNames } from './renewNames.js'
+	publicClient,
+	testClient,
+	waitForTransaction,
+	walletClient,
+} from "../../test/addTestContracts.js";
+import { getPrice } from "../public/getPrice.js";
+import { renewNames } from "./renewNames.js";
 
-let snapshot: Hex
-let accounts: Address[]
+let snapshot: Hex;
+let accounts: Address[];
 
 beforeAll(async () => {
-  accounts = await walletClient.getAddresses()
-})
+	accounts = await walletClient.getAddresses();
+});
 
 beforeEach(async () => {
-  snapshot = await testClient.snapshot()
-})
+	snapshot = await testClient.snapshot();
+});
 
 afterEach(async () => {
-  await testClient.revert({ id: snapshot })
-})
+	await testClient.revert({ id: snapshot });
+});
 
 const getExpiry = async (name: string) => {
-  return publicClient.readContract({
-    abi: baseRegistrarNameExpiresSnippet,
-    functionName: 'nameExpires',
-    address: getChainContractAddress({
-      client: publicClient,
-      contract: 'ensBaseRegistrarImplementation',
-    }),
-    args: [BigInt(labelhash(name.split('.')[0]))],
-  })
-}
+	return publicClient.readContract({
+		abi: baseRegistrarNameExpiresSnippet,
+		functionName: "nameExpires",
+		address: getChainContractAddress({
+			client: publicClient,
+			contract: "ensBaseRegistrarImplementation",
+		}),
+		args: [BigInt(labelhash(name.split(".")[0]))],
+	});
+};
 
-it('should return a renew transaction for a single name and succeed', async () => {
-  const name = 'to-be-renewed.eth'
-  const duration = 31536000n
+it("should return a renew transaction for a single name and succeed", async () => {
+	const name = "to-be-renewed.eth";
+	const duration = 31536000n;
 
-  const oldExpiry = await getExpiry(name)
+	const oldExpiry = await getExpiry(name);
 
-  const price = await getPrice(publicClient, {
-    nameOrNames: name,
-    duration,
-  })
-  const total = price!.base + price!.premium
+	const price = await getPrice(publicClient, {
+		nameOrNames: name,
+		duration,
+	});
+	const total = price!.base + price!.premium;
 
-  const tx = await renewNames(walletClient, {
-    nameOrNames: name,
-    duration,
-    value: total,
-    account: accounts[0],
-  })
-  expect(tx).toBeTruthy()
-  const receipt = await waitForTransaction(tx)
-  expect(receipt.status).toBe('success')
+	const tx = await renewNames(walletClient, {
+		nameOrNames: name,
+		duration,
+		value: total,
+		account: accounts[0],
+	});
+	expect(tx).toBeTruthy();
+	const receipt = await waitForTransaction(tx);
+	expect(receipt.status).toBe("success");
 
-  const newExpiry = await getExpiry(name)
-  expect(newExpiry).toBe(oldExpiry + duration)
-})
+	const newExpiry = await getExpiry(name);
+	expect(newExpiry).toBe(oldExpiry + duration);
+});
 
-it('should return a renewAll transaction for multiple names and succeed', async () => {
-  const names = ['to-be-renewed.eth', 'test123.eth']
-  const duration = 31536000n
+it("should throw an error when trying to renew multiple names", async () => {
+	const names = ["to-be-renewed.eth", "test123.eth"];
+	const duration = 31536000n;
 
-  const oldExpiries = await Promise.all(names.map(getExpiry))
-
-  const price = await getPrice(publicClient, {
-    nameOrNames: names,
-    duration,
-  })
-  const total = price!.base + price!.premium
-
-  const tx = await renewNames(walletClient, {
-    nameOrNames: names,
-    duration,
-    value: total,
-    account: accounts[1],
-  })
-  expect(tx).toBeTruthy()
-  const receipt = await waitForTransaction(tx)
-  expect(receipt.status).toBe('success')
-
-  const newExpiries = await Promise.all(names.map(getExpiry))
-  for (let i = 0; i < names.length; i += 1) {
-    expect(newExpiries[i]).toBe(oldExpiries[i] + duration)
-  }
-})
+	await expect(
+		renewNames(walletClient, {
+			nameOrNames: names,
+			duration,
+			value: 1000000000000000000n,
+			account: accounts[1],
+		}),
+	).rejects.toThrow("Array of names is not currently supported for renewals");
+});

--- a/packages/ensjs/src/actions/wallet/renewNames.ts
+++ b/packages/ensjs/src/actions/wallet/renewNames.ts
@@ -12,7 +12,6 @@ import {
 	getChainContractAddress,
 	type RequireClientContracts,
 } from "../../clients/chain.js";
-import { bulkRenewalRenewAllSnippet } from "../../contracts/bulkRenewal.js";
 import type { ChainWithContract } from "../../contracts/consts.js";
 import { l2EthRegistrarRenewSnippet } from "../../contracts/l2EthRegistrar.js";
 import { UnsupportedNameTypeError } from "../../errors/general.js";
@@ -32,11 +31,11 @@ import { getNameType } from "../../utils/name/getNameType.js";
 // ================================
 
 export type RenewNamesWriteParametersParameters = {
-	/** Name or names to renew */
+	/** Name to renew */
 	nameOrNames: string | string[];
-	/** Duration to renew name(s) for */
+	/** Duration to renew name for */
 	duration: bigint | number;
-	/** Value of all renewals */
+	/** Value of renewal */
 	value: bigint;
 };
 
@@ -52,27 +51,24 @@ export const renewNamesWriteParameters = <
 	chain extends Chain,
 	account extends Account,
 >(
-	client: RequireClientContracts<
-		chain,
-		"ensEthRegistrarController" | "ensBulkRenewal",
-		account
-	>,
+	client: RequireClientContracts<chain, "ensEthRegistrarController", account>,
 	{ nameOrNames, duration, value }: RenewNamesWriteParametersParameters,
 ) => {
 	ASSERT_NO_TYPE_ERROR(client);
 
-	const names = Array.isArray(nameOrNames) ? nameOrNames : [nameOrNames];
-	const labels = names.map((name) => {
-		const label = name.split(".");
-		const nameType = getNameType(name);
-		if (nameType !== "eth-2ld")
-			throw new UnsupportedNameTypeError({
-				nameType,
-				supportedNameTypes: ["eth-2ld"],
-				details: "Only 2ld-eth renewals are currently supported",
-			});
-		return label[0];
-	});
+	if (Array.isArray(nameOrNames)) {
+		throw new Error("Array of names is not currently supported for renewals");
+	}
+
+	const name = nameOrNames;
+	const label = name.split(".");
+	const nameType = getNameType(name);
+	if (nameType !== "eth-2ld")
+		throw new UnsupportedNameTypeError({
+			nameType,
+			supportedNameTypes: ["eth-2ld"],
+			details: "Only 2ld-eth renewals are currently supported",
+		});
 
 	const baseParams = {
 		chain: client.chain,
@@ -80,28 +76,15 @@ export const renewNamesWriteParameters = <
 		value,
 	} as const;
 
-	if (labels.length === 1) {
-		return {
-			...baseParams,
-			address: getChainContractAddress({
-				chain: client.chain,
-				contract: "ensEthRegistrarController",
-			}),
-			abi: l2EthRegistrarRenewSnippet,
-			functionName: "renew",
-			args: [labels[0], BigInt(duration)],
-		} as const satisfies WriteContractParameters;
-	}
-
 	return {
 		...baseParams,
 		address: getChainContractAddress({
 			chain: client.chain,
-			contract: "ensBulkRenewal",
+			contract: "ensEthRegistrarController",
 		}),
-		abi: bulkRenewalRenewAllSnippet,
-		functionName: "renewAll",
-		args: [labels, BigInt(duration)],
+		abi: l2EthRegistrarRenewSnippet,
+		functionName: "renew",
+		args: [label[0], BigInt(duration)],
 	} as const satisfies WriteContractParameters;
 };
 
@@ -113,7 +96,7 @@ export type RenewNamesParameters<
 	chain extends Chain,
 	account extends Account,
 	chainOverride extends
-		| ChainWithContract<"ensEthRegistrarController" | "ensBulkRenewal">
+		| ChainWithContract<"ensEthRegistrarController">
 		| undefined,
 > = Prettify<
 	RenewNamesWriteParametersParameters &
@@ -162,14 +145,10 @@ export async function renewNames<
 	chain extends Chain,
 	account extends Account,
 	chainOverride extends
-		| ChainWithContract<"ensEthRegistrarController" | "ensBulkRenewal">
+		| ChainWithContract<"ensEthRegistrarController">
 		| undefined,
 >(
-	client: RequireClientContracts<
-		chain,
-		"ensEthRegistrarController" | "ensBulkRenewal",
-		account
-	>,
+	client: RequireClientContracts<chain, "ensEthRegistrarController", account>,
 	{
 		nameOrNames,
 		duration,

--- a/packages/ensjs/src/actions/wallet/renewNames.ts
+++ b/packages/ensjs/src/actions/wallet/renewNames.ts
@@ -1,128 +1,131 @@
 import type {
-  Account,
-  Chain,
-  GetChainContractAddressErrorType,
-  WriteContractErrorType,
-  WriteContractParameters,
-  WriteContractReturnType,
-} from 'viem'
-import { writeContract } from 'viem/actions'
-import { getAction } from 'viem/utils'
+	Account,
+	Chain,
+	GetChainContractAddressErrorType,
+	WriteContractErrorType,
+	WriteContractParameters,
+	WriteContractReturnType,
+} from "viem";
+import { writeContract } from "viem/actions";
+import { getAction } from "viem/utils";
 import {
-  getChainContractAddress,
-  type RequireClientContracts,
-} from '../../clients/chain.js'
-import { bulkRenewalRenewAllSnippet } from '../../contracts/bulkRenewal.js'
-import type { ChainWithContract } from '../../contracts/consts.js'
-import { ethRegistrarControllerRenewSnippet } from '../../contracts/ethRegistrarController.js'
-import { UnsupportedNameTypeError } from '../../errors/general.js'
-import type { Prettify, WriteTransactionParameters } from '../../types/index.js'
-import { ASSERT_NO_TYPE_ERROR } from '../../types/internal.js'
+	getChainContractAddress,
+	type RequireClientContracts,
+} from "../../clients/chain.js";
+import { bulkRenewalRenewAllSnippet } from "../../contracts/bulkRenewal.js";
+import type { ChainWithContract } from "../../contracts/consts.js";
+import { l2EthRegistrarRenewSnippet } from "../../contracts/l2EthRegistrar.js";
+import { UnsupportedNameTypeError } from "../../errors/general.js";
+import type {
+	Prettify,
+	WriteTransactionParameters,
+} from "../../types/index.js";
+import { ASSERT_NO_TYPE_ERROR } from "../../types/internal.js";
 import {
-  type ClientWithOverridesErrorType,
-  clientWithOverrides,
-} from '../../utils/clientWithOverrides.js'
-import { getNameType } from '../../utils/name/getNameType.js'
+	type ClientWithOverridesErrorType,
+	clientWithOverrides,
+} from "../../utils/clientWithOverrides.js";
+import { getNameType } from "../../utils/name/getNameType.js";
 
 // ================================
 // Write parameters
 // ================================
 
 export type RenewNamesWriteParametersParameters = {
-  /** Name or names to renew */
-  nameOrNames: string | string[]
-  /** Duration to renew name(s) for */
-  duration: bigint | number
-  /** Value of all renewals */
-  value: bigint
-}
+	/** Name or names to renew */
+	nameOrNames: string | string[];
+	/** Duration to renew name(s) for */
+	duration: bigint | number;
+	/** Value of all renewals */
+	value: bigint;
+};
 
 export type RenewNamesWriteParametersReturnType = ReturnType<
-  typeof renewNamesWriteParameters
->
+	typeof renewNamesWriteParameters
+>;
 
 export type RenewNamesWriteParametersErrorType =
-  | UnsupportedNameTypeError
-  | GetChainContractAddressErrorType
+	| UnsupportedNameTypeError
+	| GetChainContractAddressErrorType;
 
 export const renewNamesWriteParameters = <
-  chain extends Chain,
-  account extends Account,
+	chain extends Chain,
+	account extends Account,
 >(
-  client: RequireClientContracts<
-    chain,
-    'ensEthRegistrarController' | 'ensBulkRenewal',
-    account
-  >,
-  { nameOrNames, duration, value }: RenewNamesWriteParametersParameters,
+	client: RequireClientContracts<
+		chain,
+		"ensEthRegistrarController" | "ensBulkRenewal",
+		account
+	>,
+	{ nameOrNames, duration, value }: RenewNamesWriteParametersParameters,
 ) => {
-  ASSERT_NO_TYPE_ERROR(client)
+	ASSERT_NO_TYPE_ERROR(client);
 
-  const names = Array.isArray(nameOrNames) ? nameOrNames : [nameOrNames]
-  const labels = names.map((name) => {
-    const label = name.split('.')
-    const nameType = getNameType(name)
-    if (nameType !== 'eth-2ld')
-      throw new UnsupportedNameTypeError({
-        nameType,
-        supportedNameTypes: ['eth-2ld'],
-        details: 'Only 2ld-eth renewals are currently supported',
-      })
-    return label[0]
-  })
+	const names = Array.isArray(nameOrNames) ? nameOrNames : [nameOrNames];
+	const labels = names.map((name) => {
+		const label = name.split(".");
+		const nameType = getNameType(name);
+		if (nameType !== "eth-2ld")
+			throw new UnsupportedNameTypeError({
+				nameType,
+				supportedNameTypes: ["eth-2ld"],
+				details: "Only 2ld-eth renewals are currently supported",
+			});
+		return label[0];
+	});
 
-  const baseParams = {
-    chain: client.chain,
-    account: client.account,
-    value,
-  } as const
+	const baseParams = {
+		chain: client.chain,
+		account: client.account,
+		value,
+	} as const;
 
-  if (labels.length === 1) {
-    return {
-      ...baseParams,
-      address: getChainContractAddress({
-        chain: client.chain,
-        contract: 'ensEthRegistrarController',
-      }),
-      abi: ethRegistrarControllerRenewSnippet,
-      functionName: 'renew',
-      args: [labels[0], BigInt(duration)],
-    } as const satisfies WriteContractParameters
-  }
+	if (labels.length === 1) {
+		return {
+			...baseParams,
+			address: getChainContractAddress({
+				chain: client.chain,
+				contract: "ensEthRegistrarController",
+			}),
+			abi: l2EthRegistrarRenewSnippet,
+			functionName: "renew",
+			args: [labels[0], BigInt(duration)],
+		} as const satisfies WriteContractParameters;
+	}
 
-  return {
-    ...baseParams,
-    address: getChainContractAddress({
-      chain: client.chain,
-      contract: 'ensBulkRenewal',
-    }),
-    abi: bulkRenewalRenewAllSnippet,
-    functionName: 'renewAll',
-    args: [labels, BigInt(duration)],
-  } as const satisfies WriteContractParameters
-}
+	return {
+		...baseParams,
+		address: getChainContractAddress({
+			chain: client.chain,
+			contract: "ensBulkRenewal",
+		}),
+		abi: bulkRenewalRenewAllSnippet,
+		functionName: "renewAll",
+		args: [labels, BigInt(duration)],
+	} as const satisfies WriteContractParameters;
+};
 
 // ================================
 // Renew names action
 // ================================
 
 export type RenewNamesParameters<
-  chain extends Chain,
-  account extends Account,
-  chainOverride extends
-    | ChainWithContract<'ensEthRegistrarController' | 'ensBulkRenewal'>
-    | undefined,
+	chain extends Chain,
+	account extends Account,
+	chainOverride extends
+		| ChainWithContract<"ensEthRegistrarController" | "ensBulkRenewal">
+		| undefined,
 > = Prettify<
-  RenewNamesWriteParametersParameters &
-    WriteTransactionParameters<chain, account, chainOverride>
->
+	RenewNamesWriteParametersParameters &
+		WriteTransactionParameters<chain, account, chainOverride>
+>;
 
-export type RenewNamesReturnType = WriteContractReturnType
+export type RenewNamesReturnType = WriteContractReturnType;
 
 export type RenewNamesErrorType =
-  | RenewNamesWriteParametersErrorType
-  | ClientWithOverridesErrorType
-  | WriteContractErrorType
+	| RenewNamesWriteParametersErrorType
+	| ClientWithOverridesErrorType
+	| WriteContractErrorType;
 
 /**
  * Renews a name or names for a specified duration.
@@ -156,33 +159,33 @@ export type RenewNamesErrorType =
  * // 0x...
  */
 export async function renewNames<
-  chain extends Chain,
-  account extends Account,
-  chainOverride extends
-    | ChainWithContract<'ensEthRegistrarController' | 'ensBulkRenewal'>
-    | undefined,
+	chain extends Chain,
+	account extends Account,
+	chainOverride extends
+		| ChainWithContract<"ensEthRegistrarController" | "ensBulkRenewal">
+		| undefined,
 >(
-  client: RequireClientContracts<
-    chain,
-    'ensEthRegistrarController' | 'ensBulkRenewal',
-    account
-  >,
-  {
-    nameOrNames,
-    duration,
-    value,
-    ...txArgs
-  }: RenewNamesParameters<chain, account, chainOverride>,
+	client: RequireClientContracts<
+		chain,
+		"ensEthRegistrarController" | "ensBulkRenewal",
+		account
+	>,
+	{
+		nameOrNames,
+		duration,
+		value,
+		...txArgs
+	}: RenewNamesParameters<chain, account, chainOverride>,
 ): Promise<RenewNamesReturnType> {
-  ASSERT_NO_TYPE_ERROR(client)
+	ASSERT_NO_TYPE_ERROR(client);
 
-  const writeParameters = renewNamesWriteParameters(
-    clientWithOverrides(client, txArgs),
-    { nameOrNames, duration, value },
-  )
-  const writeContractAction = getAction(client, writeContract, 'writeContract')
-  return writeContractAction({
-    ...writeParameters,
-    ...txArgs,
-  } as WriteContractParameters)
+	const writeParameters = renewNamesWriteParameters(
+		clientWithOverrides(client, txArgs),
+		{ nameOrNames, duration, value },
+	);
+	const writeContractAction = getAction(client, writeContract, "writeContract");
+	return writeContractAction({
+		...writeParameters,
+		...txArgs,
+	} as WriteContractParameters);
 }

--- a/packages/ensjs/src/contracts/l2EthRegistrar.ts
+++ b/packages/ensjs/src/contracts/l2EthRegistrar.ts
@@ -1,245 +1,282 @@
 export const l2EthRegistrarErrors = [
-  {
-    inputs: [
-      {
-        name: 'commitment',
-        type: 'bytes32',
-      },
-      {
-        name: 'validFrom',
-        type: 'uint256',
-      },
-      {
-        name: 'blockTimestamp',
-        type: 'uint256',
-      },
-    ],
-    name: 'CommitmentTooNew',
-    type: 'error',
-  },
-  {
-    inputs: [
-      {
-        name: 'commitment',
-        type: 'bytes32',
-      },
-      {
-        name: 'validTo',
-        type: 'uint256',
-      },
-      {
-        name: 'blockTimestamp',
-        type: 'uint256',
-      },
-    ],
-    name: 'CommitmentTooOld',
-    type: 'error',
-  },
-  {
-    inputs: [
-      {
-        name: 'duration',
-        type: 'uint64',
-      },
-      {
-        name: 'minDuration',
-        type: 'uint256',
-      },
-    ],
-    name: 'DurationTooShort',
-    type: 'error',
-  },
-  {
-    inputs: [
-      {
-        name: 'required',
-        type: 'uint256',
-      },
-      {
-        name: 'provided',
-        type: 'uint256',
-      },
-    ],
-    name: 'InsufficientValue',
-    type: 'error',
-  },
-  {
-    inputs: [],
-    name: 'MaxCommitmentAgeTooLow',
-    type: 'error',
-  },
-  {
-    inputs: [
-      {
-        name: 'name',
-        type: 'string',
-      },
-    ],
-    name: 'NameNotAvailable',
-    type: 'error',
-  },
-  {
-    inputs: [
-      {
-        name: 'commitment',
-        type: 'bytes32',
-      },
-    ],
-    name: 'UnexpiredCommitmentExists',
-    type: 'error',
-  },
-] as const
+	{
+		inputs: [
+			{
+				name: "commitment",
+				type: "bytes32",
+			},
+			{
+				name: "validFrom",
+				type: "uint256",
+			},
+			{
+				name: "blockTimestamp",
+				type: "uint256",
+			},
+		],
+		name: "CommitmentTooNew",
+		type: "error",
+	},
+	{
+		inputs: [
+			{
+				name: "commitment",
+				type: "bytes32",
+			},
+			{
+				name: "validTo",
+				type: "uint256",
+			},
+			{
+				name: "blockTimestamp",
+				type: "uint256",
+			},
+		],
+		name: "CommitmentTooOld",
+		type: "error",
+	},
+	{
+		inputs: [
+			{
+				name: "duration",
+				type: "uint64",
+			},
+			{
+				name: "minDuration",
+				type: "uint256",
+			},
+		],
+		name: "DurationTooShort",
+		type: "error",
+	},
+	{
+		inputs: [
+			{
+				name: "required",
+				type: "uint256",
+			},
+			{
+				name: "provided",
+				type: "uint256",
+			},
+		],
+		name: "InsufficientValue",
+		type: "error",
+	},
+	{
+		inputs: [],
+		name: "MaxCommitmentAgeTooLow",
+		type: "error",
+	},
+	{
+		inputs: [
+			{
+				name: "name",
+				type: "string",
+			},
+		],
+		name: "NameNotAvailable",
+		type: "error",
+	},
+	{
+		inputs: [
+			{
+				name: "commitment",
+				type: "bytes32",
+			},
+		],
+		name: "UnexpiredCommitmentExists",
+		type: "error",
+	},
+] as const;
 
 export const l2EthRegistrarRentPriceSnippet = [
-  ...l2EthRegistrarErrors,
-  {
-    inputs: [
-      {
-        name: 'name',
-        type: 'string',
-      },
-      {
-        name: 'duration',
-        type: 'uint256',
-      },
-    ],
-    name: 'rentPrice',
-    outputs: [
-      {
-        components: [
-          {
-            name: 'base',
-            type: 'uint256',
-          },
-          {
-            name: 'premium',
-            type: 'uint256',
-          },
-        ],
-        name: 'price',
-        type: 'tuple',
-      },
-    ],
-    stateMutability: 'view',
-    type: 'function',
-  },
-] as const
+	...l2EthRegistrarErrors,
+	{
+		inputs: [
+			{
+				name: "name",
+				type: "string",
+			},
+			{
+				name: "duration",
+				type: "uint256",
+			},
+		],
+		name: "rentPrice",
+		outputs: [
+			{
+				components: [
+					{
+						name: "base",
+						type: "uint256",
+					},
+					{
+						name: "premium",
+						type: "uint256",
+					},
+				],
+				name: "price",
+				type: "tuple",
+			},
+		],
+		stateMutability: "view",
+		type: "function",
+	},
+] as const;
 
 export const l2EthRegistrarCommitSnippet = [
-  ...l2EthRegistrarErrors,
-  {
-    inputs: [
-      {
-        name: 'commitment',
-        type: 'bytes32',
-      },
-    ],
-    name: 'commit',
-    outputs: [],
-    stateMutability: 'nonpayable',
-    type: 'function',
-  },
-] as const
+	...l2EthRegistrarErrors,
+	{
+		inputs: [
+			{
+				name: "commitment",
+				type: "bytes32",
+			},
+		],
+		name: "commit",
+		outputs: [],
+		stateMutability: "nonpayable",
+		type: "function",
+	},
+] as const;
 
 export const l2EthRegistrarMakeCommitmentSnippet = [
-  ...l2EthRegistrarErrors,
-  {
-    inputs: [
-      {
-        name: 'name',
-        type: 'string',
-      },
-      {
-        name: 'owner',
-        type: 'address',
-      },
-      {
-        name: 'secret',
-        type: 'bytes32',
-      },
-      {
-        name: 'subregistry',
-        type: 'address',
-      },
-      {
-        name: 'resolver',
-        type: 'address',
-      },
-      {
-        name: 'duration',
-        type: 'uint64',
-      },
-    ],
-    name: 'makeCommitment',
-    outputs: [
-      {
-        name: '',
-        type: 'bytes32',
-      },
-    ],
-    stateMutability: 'pure',
-    type: 'function',
-  },
-] as const
+	...l2EthRegistrarErrors,
+	{
+		inputs: [
+			{
+				name: "name",
+				type: "string",
+			},
+			{
+				name: "owner",
+				type: "address",
+			},
+			{
+				name: "secret",
+				type: "bytes32",
+			},
+			{
+				name: "subregistry",
+				type: "address",
+			},
+			{
+				name: "resolver",
+				type: "address",
+			},
+			{
+				name: "duration",
+				type: "uint64",
+			},
+		],
+		name: "makeCommitment",
+		outputs: [
+			{
+				name: "",
+				type: "bytes32",
+			},
+		],
+		stateMutability: "pure",
+		type: "function",
+	},
+] as const;
 
 export const l2EthRegistrarCommitmentsSnippet = [
-  ...l2EthRegistrarErrors,
-  {
-    inputs: [
-      {
-        name: '',
-        type: 'bytes32',
-      },
-    ],
-    name: 'commitments',
-    outputs: [
-      {
-        name: '',
-        type: 'uint256',
-      },
-    ],
-    stateMutability: 'view',
-    type: 'function',
-  },
-] as const
+	...l2EthRegistrarErrors,
+	{
+		inputs: [
+			{
+				name: "",
+				type: "bytes32",
+			},
+		],
+		name: "commitments",
+		outputs: [
+			{
+				name: "",
+				type: "uint256",
+			},
+		],
+		stateMutability: "view",
+		type: "function",
+	},
+] as const;
 
 export const l2EthRegistrarRegisterSnippet = [
-  ...l2EthRegistrarErrors,
-  {
-    inputs: [
-      {
-        name: 'name',
-        type: 'string',
-      },
-      {
-        name: 'owner',
-        type: 'address',
-      },
-      {
-        name: 'secret',
-        type: 'bytes32',
-      },
-      {
-        name: 'subregistry',
-        type: 'address',
-      },
-      {
-        name: 'resolver',
-        type: 'address',
-      },
-      {
-        name: 'duration',
-        type: 'uint64',
-      },
-    ],
-    name: 'register',
-    outputs: [
-      {
-        name: '',
-        type: 'uint256',
-      },
-    ],
-    stateMutability: 'payable',
-    type: 'function',
-  },
-] as const
+	...l2EthRegistrarErrors,
+	{
+		inputs: [
+			{
+				name: "name",
+				type: "string",
+			},
+			{
+				name: "owner",
+				type: "address",
+			},
+			{
+				name: "secret",
+				type: "bytes32",
+			},
+			{
+				name: "subregistry",
+				type: "address",
+			},
+			{
+				name: "resolver",
+				type: "address",
+			},
+			{
+				name: "duration",
+				type: "uint64",
+			},
+		],
+		name: "register",
+		outputs: [
+			{
+				name: "",
+				type: "uint256",
+			},
+		],
+		stateMutability: "payable",
+		type: "function",
+	},
+] as const;
+
+export const l2EthRegistrarRenewErrors = [
+	{
+		inputs: [
+			{
+				name: "required",
+				type: "uint256",
+			},
+			{
+				name: "provided",
+				type: "uint256",
+			},
+		],
+		name: "InsufficientValue",
+		type: "error",
+	},
+] as const;
+
+export const l2EthRegistrarRenewSnippet = [
+	...l2EthRegistrarRenewErrors,
+	{
+		inputs: [
+			{
+				name: "name",
+				type: "string",
+			},
+			{
+				name: "duration",
+				type: "uint64",
+			},
+		],
+		name: "renew",
+		outputs: [],
+		stateMutability: "payable",
+		type: "function",
+	},
+] as const;


### PR DESCRIPTION
# Add L2 Registrar Renew Support

## Changes

### Added L2 Registrar Renew ABI Support:
- ✨ Added `l2EthRegistrarRenewErrors` with `InsufficientValue` error specific to renew function
- ✨ Added `l2EthRegistrarRenewSnippet` ABI snippet for L2 registrar renew function with:
  - `name` (string) and `duration` (uint64) parameters  
  - Payable state mutability
  - Proper error handling

### Updated Renew Action:
- 🔄 Updated `renewNames.ts` to use `l2EthRegistrarRenewSnippet` instead of `ethRegistrarControllerRenewSnippet`
- 🔄 Switched import from `ethRegistrarController.js` to `l2EthRegistrar.js`

## Summary
This PR adds support for the L2 registrar's renew function by creating the necessary ABI snippets and integrating them into the existing renewNames action. The implementation follows the established pattern of modular error handling and function-specific ABI snippets.

## Files Changed
- `packages/ensjs/src/contracts/l2EthRegistrar.ts`
- `packages/ensjs/src/actions/wallet/renewNames.ts`