### PR TITLE
fix: getname behaviour

### DIFF
--- a/packages/ensjs/src/errors/public.ts
+++ b/packages/ensjs/src/errors/public.ts
@@ -1,3 +1,4 @@
+import type { Address } from 'viem'
 import { BaseError } from './base.js'
 
 export class CoinFormatterNotFoundError extends BaseError {
@@ -27,5 +28,29 @@ export class NoRecordsSpecifiedError extends BaseError {
 
   constructor() {
     super('No records specified')
+  }
+}
+
+export class NameNotNormalisedError extends BaseError {
+  override name = 'NameNotNormalisedError'
+
+  address: Address
+  resolvedName: string
+  coinType: number
+
+  constructor({
+    address,
+    resolvedName,
+    coinType,
+  }: { address: Address; resolvedName: string; coinType: number }) {
+    super(`Name ${resolvedName} resolved from address is not normalised`, {
+      metaMessages: [
+        `- Resolved from address: ${address}`,
+        `Resolved for coinType: ${coinType}`,
+      ],
+    })
+    this.address = address
+    this.resolvedName = resolvedName
+    this.coinType = coinType
   }
 }

--- a/packages/ensjs/src/functions/public/getName.ts
+++ b/packages/ensjs/src/functions/public/getName.ts
@@ -14,6 +14,7 @@ import {
   universalResolverReverseSnippet,
   universalResolverReverseWithGatewaysSnippet,
 } from '../../contracts/universalResolver.js'
+import { NameNotNormalisedError } from '../../errors/public.js'
 import type {
   GenericPassthrough,
   TransactionRequestWithPassthrough,
@@ -154,9 +155,14 @@ const decode = async (
 
     if (!unnormalisedName) return null
 
-    const normalisedName = normalise(unnormalisedName)
+    if (unnormalisedName !== normalise(unnormalisedName))
+      throw new NameNotNormalisedError({
+        address: passthrough.address,
+        resolvedName: unnormalisedName,
+        coinType: passthrough.args[1] as number,
+      })
     return {
-      name: normalisedName,
+      name: unnormalisedName,
       match: true,
       reverseResolverAddress,
       resolverAddress,

--- a/packages/ensjs/src/test/addTestContracts.ts
+++ b/packages/ensjs/src/test/addTestContracts.ts
@@ -1,7 +1,6 @@
-import { resolve } from 'node:path'
 import { config } from 'dotenv'
+import { resolve } from 'node:path'
 import {
-  http,
   type Account,
   type Address,
   type Hash,
@@ -13,6 +12,7 @@ import {
   createPublicClient,
   createTestClient,
   createWalletClient,
+  http,
 } from 'viem'
 import { localhost as _localhost } from 'viem/chains'
 
@@ -104,6 +104,7 @@ export const publicClient: PublicClient<typeof transport, typeof localhost> =
   createPublicClient({
     chain: localhost,
     transport,
+    cacheTime: 0,
   })
 
 export const testClient: TestClient<
@@ -125,18 +126,23 @@ export const walletClient: WalletClient<
   transport,
 })
 
-export const waitForTransaction = async (hash: Hash) =>
-  new Promise<TransactionReceipt>((resolveFn, reject) => {
-    publicClient
-      .getTransactionReceipt({ hash })
-      .then(resolveFn)
-      .catch((e) => {
-        if (e instanceof TransactionReceiptNotFoundError) {
-          setTimeout(() => {
-            waitForTransaction(hash).then(resolveFn)
-          }, 100)
-        } else {
-          reject(e)
-        }
-      })
-  })
+export const waitForTransaction = async (
+  hash: Hash,
+): Promise<TransactionReceipt> => {
+  const receipt = await publicClient
+    .getTransactionReceipt({ hash })
+    .catch((e) => {
+      if (e instanceof TransactionReceiptNotFoundError) return null
+      throw e
+    })
+  if (receipt === null) {
+    return new Promise<TransactionReceipt>((resolve, reject) => {
+      setTimeout(() => {
+        waitForTransaction(hash).then(resolve).catch(reject)
+      }, 100)
+    })
+  }
+
+  if (receipt.status !== 'success') throw new Error('Transaction failed')
+  return receipt
+}

--- a/packages/ensjs/src/test/addTestContracts.ts
+++ b/packages/ensjs/src/test/addTestContracts.ts
@@ -1,6 +1,7 @@
-import { config } from 'dotenv'
 import { resolve } from 'node:path'
+import { config } from 'dotenv'
 import {
+  http,
   type Account,
   type Address,
   type Hash,
@@ -12,7 +13,6 @@ import {
   createPublicClient,
   createTestClient,
   createWalletClient,
-  http,
 } from 'viem'
 import { localhost as _localhost } from 'viem/chains'
 


### PR DESCRIPTION
if a resolved primary name is not normalised, the result should be null or an error, rather than normalising the output. this was theoretically being tested already but `createSubname` and `setAddressRecord` both use the `namehash` function in ensjs itself, which normalises all labels, and we weren't testing for the error output in strict mode, just that the result is null.

changes:
- added normalisation check in `getName`. if false (not normalised), there is a new `NameNotNormalisedError` that can be thrown in strict mode, or non strict will return `null`.
- getName test now uses `writeContract` + viem's `namehash` to avoid the normalisation in the `namehash` from ensjs
- `waitForTransaction` now checks that a transaction was successful in it's receipt