### PR TITLE
fix(fuses): correct checkPccBurned logic to check for burned fuse

### DIFF
--- a/packages/ensjs/src/utils/fuses.test.ts
+++ b/packages/ensjs/src/utils/fuses.test.ts
@@ -11,6 +11,7 @@ import {
   UnnamedParentFuses,
   UserSettableFuseKeys,
   UserSettableFuses,
+  checkPccBurned,
   decodeFuses,
   encodeFuses,
 } from './fuses.js'
@@ -721,5 +722,28 @@ describe('decodeFuses', () => {
         }),
       }),
     )
+  })
+})
+
+describe('checkPccBurned', () => {
+  it('returns true when PARENT_CANNOT_CONTROL fuse is burned', () => {
+    // 0x10000n is PARENT_CANNOT_CONTROL
+    expect(checkPccBurned(ParentFuses.PARENT_CANNOT_CONTROL)).toBe(true)
+  })
+  it('returns true when PARENT_CANNOT_CONTROL is burned along with other fuses', () => {
+    // PARENT_CANNOT_CONTROL | CAN_EXTEND_EXPIRY | CANNOT_UNWRAP
+    const fuses =
+      ParentFuses.PARENT_CANNOT_CONTROL |
+      ParentFuses.CAN_EXTEND_EXPIRY |
+      ChildFuses.CANNOT_UNWRAP
+    expect(checkPccBurned(fuses)).toBe(true)
+  })
+  it('returns false when PARENT_CANNOT_CONTROL fuse is not burned', () => {
+    expect(checkPccBurned(0n)).toBe(false)
+  })
+  it('returns false when only other fuses are burned', () => {
+    // CAN_EXTEND_EXPIRY | CANNOT_UNWRAP (no PARENT_CANNOT_CONTROL)
+    const fuses = ParentFuses.CAN_EXTEND_EXPIRY | ChildFuses.CANNOT_UNWRAP
+    expect(checkPccBurned(fuses)).toBe(false)
   })
 })

--- a/packages/ensjs/src/utils/fuses.ts
+++ b/packages/ensjs/src/utils/fuses.ts
@@ -383,4 +383,5 @@ export const decodeFuses = (fuses: number): DecodedFuses => {
 }
 
 export const checkPccBurned = (fuses: bigint) =>
-  (fuses & ParentFuses.PARENT_CANNOT_CONTROL) === 0n
+  (fuses & ParentFuses.PARENT_CANNOT_CONTROL) ===
+  ParentFuses.PARENT_CANNOT_CONTROL


### PR DESCRIPTION
## Summary
- Fixed `checkPccBurned` function which was returning the opposite of its intended result
- The function was checking `=== 0n` (true when fuse is NOT set) instead of `=== PARENT_CANNOT_CONTROL` (true when fuse IS set/burned)
- Added unit tests to prevent regression

## The Bug
```typescript
// Before (wrong): returns true when fuse is NOT burned
(fuses & ParentFuses.PARENT_CANNOT_CONTROL) === 0n

// After (correct): returns true when fuse IS burned
(fuses & ParentFuses.PARENT_CANNOT_CONTROL) === ParentFuses.PARENT_CANNOT_CONTROL
```

## Test Plan
- [x] Added 4 unit tests for `checkPccBurned` function
- [x] All tests pass locally

Fixes #268