### PR TITLE
fix(ensjs): normalise the label in getAvailable before hashing

### DIFF
--- a/packages/ensjs/src/functions/public/getAvailable.test.ts
+++ b/packages/ensjs/src/functions/public/getAvailable.test.ts
@@ -15,4 +15,15 @@ describe('getAvailable', () => {
     expect(typeof result).toBe('boolean')
     expect(result).toBe(true)
   })
+  it('normalises the label before hashing, so a non-normalised name checks the canonical id', () => {
+    // 😠️ carries a U+FE0F variation selector that ENSIP-15 normalisation
+    // strips. Before the fix, the raw label hashed to a different tokenId than
+    // the canonical 😠.eth, so `available` was checked against the wrong id.
+    // Both forms must now produce identical availability calldata.
+    const withVariationSelector = getAvailable.encode(publicClient, {
+      name: '😠️.eth',
+    })
+    const normalised = getAvailable.encode(publicClient, { name: '😠.eth' })
+    expect(withVariationSelector.data).toEqual(normalised.data)
+  })
 })

--- a/packages/ensjs/src/functions/public/getAvailable.ts
+++ b/packages/ensjs/src/functions/public/getAvailable.ts
@@ -15,6 +15,7 @@ import {
   generateFunction,
 } from '../../utils/generateFunction.js'
 import { getNameType } from '../../utils/getNameType.js'
+import { normalise } from '../../utils/normalise.js'
 
 export type GetAvailableParameters = {
   /** Name to check availability for, only compatible for eth 2ld */
@@ -44,7 +45,13 @@ const encode = (
     data: encodeFunctionData({
       abi: baseRegistrarAvailableSnippet,
       functionName: 'available',
-      args: [BigInt(labelhash(labels[0]))],
+      // Normalise the label first (ENSIP-15). Without this, a non-normalised
+      // label (e.g. an emoji carrying a FE0F variation selector, or mixed
+      // case) hashes to a different tokenId than the canonical registered
+      // name, so `available` is checked against the wrong id and returns a
+      // wrong result. `normalise` also throws on genuinely invalid names
+      // rather than reporting them as available.
+      args: [BigInt(labelhash(normalise(labels[0])))],
     }),
   }
 }


### PR DESCRIPTION
closes #198

## the bug (ensdomains/ensjs#198)

`getAvailable` reports emoji / non-normalised names as available when they aren't. Root cause: it hashes the **raw** label instead of the ENSIP-15 **normalised** one.

`src/functions/public/getAvailable.ts` did:

```ts
args: [BigInt(labelhash(labels[0]))]
```

A label carrying a `U+FE0F` variation selector (or mixed case) hashes to a different `tokenId` than the canonical registered name, so the base registrar's `available(id)` is checked against the **wrong id** and returns a wrong result.

## verified, not guessed

```
raw '😠️'                    → codepoints [1f620, fe0f]
ens_normalize('😠️')         → '😠'  (codepoints [1f620], FE0F stripped)
labelhash(raw)              → 0xc93c7b08…5d8ba038
labelhash(normalised)       → 0xff9e45e5…41903099   ← different id → wrong availability
```

## the fix

Normalise the label with ensjs's own `utils/normalise` before hashing:

```ts
args: [BigInt(labelhash(normalise(labels[0])))]
```

Side effect (correct): genuinely invalid names now `throw` (via `ens_normalize`) instead of being reported available. Already-normalised names (the existing tests) are unchanged, since `normalise` is identity on them.

## receipts

```
$ pnpm build   (tsc)                         → exit 0
$ biome check ./src/.../getAvailable.ts      → 0 warnings
$ vitest run getAvailable -t "normalises"    → 1 passed
```

New offline regression test asserts `getAvailable.encode()` produces **identical calldata** for `😠️.eth` (with FE0F) and `😠.eth` (normalised) - i.e. the same labelhash. It uses `.encode` (pure, no RPC), so it runs without the anvil harness. The two existing integration tests are untouched (normal names normalise to themselves).
