### PR TITLE
chore(deps): bump @ensdomains/address-encoder to 1.1.4 (SUI support)

### DIFF
--- a/packages/ensjs/package.json
+++ b/packages/ensjs/package.json
@@ -87,7 +87,7 @@
   },
   "dependencies": {
     "@adraffy/ens-normalize": "1.10.1",
-    "@ensdomains/address-encoder": "1.1.3",
+    "@ensdomains/address-encoder": "1.1.4",
     "@ensdomains/content-hash": "^3.1.1",
     "@ensdomains/dnsprovejs": "0.5.1",
     "abitype": "^1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,8 +64,8 @@ importers:
         specifier: 1.10.1
         version: 1.10.1
       '@ensdomains/address-encoder':
-        specifier: 1.1.3
-        version: 1.1.3
+        specifier: 1.1.4
+        version: 1.1.4
       '@ensdomains/content-hash':
         specifier: ^3.1.1
         version: 3.1.1
@@ -371,8 +371,8 @@ packages:
   '@ensdomains/address-encoder@0.1.9':
     resolution: {integrity: sha512-E2d2gP4uxJQnDu2Kfg1tHNspefzbLT8Tyjrm5sEuim32UkU2sm5xL4VXtgc2X33fmPEw9+jUMpGs4veMbf+PYg==}
 
-  '@ensdomains/address-encoder@1.1.3':
-    resolution: {integrity: sha512-QS4ax0YkA8tsbQcWgBNmLLtb3aG0jsOQtED9SRyX9Ixflt1jDMuC/0i3ONMnNJNG5HTIko0Te4Y1JIGXjNcnUg==}
+  '@ensdomains/address-encoder@1.1.4':
+    resolution: {integrity: sha512-hBY6VxVw9A1cMPOKDIvPB2nlmgaw2dvrrj/p/9tkGWmD+qdfKYZTdZuSdFcUGxhhzEB4HeLG/a98ytlTq84KcA==}
 
   '@ensdomains/buffer@0.1.3':
     resolution: {integrity: sha512-L/GoCkQFePjSn4DeVnBNfkGdm2CI8UxTxwgQztcZ1L9aHaFefRD+mTUXxtikk946KwwMHRQJDn38wo1IWtEpSg==}
@@ -5797,7 +5797,7 @@ snapshots:
       nano-base32: 1.0.1
       ripemd160: 2.0.2
 
-  '@ensdomains/address-encoder@1.1.3':
+  '@ensdomains/address-encoder@1.1.4':
     dependencies:
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0


### PR DESCRIPTION
closes #267

## what

Bumps `@ensdomains/address-encoder` from 1.1.3 to 1.1.4, which adds SUI coin type encode/decode support ([address-encoder#409](https://github.com/ensdomains/address-encoder/pull/409)).

## safety (dependency bump)

Additive patch release, no breaking changes. Verified:

```
$ pnpm build (tsc)                     → exit 0 (no type breaks)
$ vitest run src/utils/encoders …      → 29 passed (encodeSetAddr, encodeAbi,
                                          encodeSetContentHash, encodeSetAbi -
                                          the address-encoder consumers)
```

Only `packages/ensjs` depends on it; the lockfile change is limited to the single entry.
