### PR TITLE
fix(fuses): checkPccBurned was inverted

### DIFF
--- a/packages/ensjs/src/utils/fuses.test.ts
+++ b/packages/ensjs/src/utils/fuses.test.ts
@@ -11,6 +11,7 @@ import {
   UnnamedParentFuses,
   UserSettableFuseKeys,
   UserSettableFuses,
+  checkPccBurned,
   decodeFuses,
   encodeFuses,
 } from './fuses.js'
@@ -721,5 +722,24 @@ describe('decodeFuses', () => {
         }),
       }),
     )
+  })
+})
+
+describe('checkPccBurned', () => {
+  it('returns true when PARENT_CANNOT_CONTROL is burned (set)', () => {
+    expect(checkPccBurned(ParentFuses.PARENT_CANNOT_CONTROL)).toBe(true)
+  })
+  it('returns true when PCC is burned alongside other parent fuses', () => {
+    expect(
+      checkPccBurned(
+        ParentFuses.PARENT_CANNOT_CONTROL | ParentFuses.CAN_EXTEND_EXPIRY,
+      ),
+    ).toBe(true)
+  })
+  it('returns false when no fuses are burned', () => {
+    expect(checkPccBurned(0n)).toBe(false)
+  })
+  it('returns false when a different parent fuse is burned but PCC is not', () => {
+    expect(checkPccBurned(ParentFuses.CAN_EXTEND_EXPIRY)).toBe(false)
   })
 })

--- a/packages/ensjs/src/utils/fuses.ts
+++ b/packages/ensjs/src/utils/fuses.ts
@@ -383,4 +383,5 @@ export const decodeFuses = (fuses: number): DecodedFuses => {
 }
 
 export const checkPccBurned = (fuses: bigint) =>
-  (fuses & ParentFuses.PARENT_CANNOT_CONTROL) === 0n
+  (fuses & ParentFuses.PARENT_CANNOT_CONTROL) ===
+  ParentFuses.PARENT_CANNOT_CONTROL


### PR DESCRIPTION
closes #268

## what

`checkPccBurned(fuses)` is inverted: it returns `true` when `PARENT_CANNOT_CONTROL` is **not** burned, and `false` once it **is** burned. It even returns `true` for a name with no fuses set at all.

## why

In the NameWrapper a *set* fuse bit means the fuse is *burnt*. The check compared the masked bit against `0n`, so it was actually answering "is PCC unburned?" - the opposite of what a `...Burned` predicate should return.

```ts
// before
(fuses & ParentFuses.PARENT_CANNOT_CONTROL) === 0n
// after
(fuses & ParentFuses.PARENT_CANNOT_CONTROL) === ParentFuses.PARENT_CANNOT_CONTROL
```

## how

Compare `fuses & PARENT_CANNOT_CONTROL` against the fuse bit itself, so it is `true` only when PCC is actually burned.

`checkPccBurned` is a public export with no internal callers and (per the coverage report) had no test, so this also adds the missing coverage. All four cases fail against the old impl and pass against the fix.
