### PR TITLE
fix(utils): getNameType('') returns root instead of tld

### DIFF
--- a/packages/ensjs/src/utils/getNameType.test.ts
+++ b/packages/ensjs/src/utils/getNameType.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { getNameType } from './getNameType.js'
+
+describe('getNameType', () => {
+  it('returns root for the empty string', () => {
+    expect(getNameType('')).toBe('root')
+  })
+  it('returns eth-tld for eth', () => {
+    expect(getNameType('eth')).toBe('eth-tld')
+  })
+  it('returns eth-2ld for vitalik.eth', () => {
+    expect(getNameType('vitalik.eth')).toBe('eth-2ld')
+  })
+  it('returns eth-subname for sub.vitalik.eth', () => {
+    expect(getNameType('sub.vitalik.eth')).toBe('eth-subname')
+  })
+  it('returns tld for xyz', () => {
+    expect(getNameType('xyz')).toBe('tld')
+  })
+  it('returns other-2ld for foo.xyz', () => {
+    expect(getNameType('foo.xyz')).toBe('other-2ld')
+  })
+  it('returns other-subname for sub.foo.xyz', () => {
+    expect(getNameType('sub.foo.xyz')).toBe('other-subname')
+  })
+})

--- a/packages/ensjs/src/utils/getNameType.ts
+++ b/packages/ensjs/src/utils/getNameType.ts
@@ -4,7 +4,7 @@ export const getNameType = (name: string): NameType => {
   const labels = name.split('.')
   const isDotEth = labels[labels.length - 1] === 'eth'
 
-  if (labels.length === 0) return 'root'
+  if (name === '') return 'root'
   if (labels.length === 1) {
     if (isDotEth) return 'eth-tld'
     return 'tld'


### PR DESCRIPTION
Found by inspection, no filed issue.

`getNameType('')` returned `'tld'` instead of `'root'`. `''.split('.')` returns
`['']` (length 1, not 0), so the `labels.length === 0` branch was dead code -
unreachable for any input, including the empty string itself.

This contradicts the compile-time contract: `types.ts:85` defines `RootName = ''`,
and the conditional type `GetNameType<TString>` in the same file resolves
`GetNameType<''>` to `RootNameSpecifier` (`'root'`). The runtime value disagreed
with its own type.

Fix: check `name === ''` directly instead of the always-false `labels.length === 0`.

## Behavior change, called out explicitly

Checked all 12 call sites. 11 of them are unaffected (either an allowlist guard that
throws either way, both before and after, or a binary `eth-2ld` check where `''`
lands in the same `else` branch regardless).

One site changes behavior, in the fix's favor: `getPrice.ts` allows `'tld'`
(bare-label shorthand, e.g. `getPrice('vitalik')`). Under the old bug,
`getPrice('')` passed that guard and proceeded to an on-chain `rentPrice` call with
an empty label. With the fix, it now throws `UnsupportedNameTypeError('root')`
before ever reaching that call. No legitimate caller should depend on querying the
price of an empty label, so this closes a real (if narrow) gap rather than opening
one.

Also worth noting: `createSubname.ts:104` already explicitly checks for
`nameType === 'tld' || nameType === 'root'` - a branch that was unreachable for
`'root'` until this fix. The fix makes existing, already-written intent reachable
rather than introducing new behavior from scratch.

## Testing

New `getNameType.test.ts` (didn't exist before), 7 cases covering every `NameType`
variant. Guard-validated: reverted the fix, confirmed exactly the empty-string case
fails against the old code (6 others still pass), restored. Full suite: 7/7 pass,
100% coverage on `getNameType.ts`. `tsc --noEmit` and `biome check` both clean on
the changed files.
