### PR TITLE
feat(public): add blockNumber parameter to resolver read methods

### DIFF
--- a/.changeset/blocknumber-batch-guard.md
+++ b/.changeset/blocknumber-batch-guard.md
@@ -1,0 +1,7 @@
+---
+"@ensdomains/ensjs": minor
+---
+
+`getOwner`, `getResolver`, `getRecords`, `getName`, `getExpiry`, `getPrice`, `getAddressRecord`, `getTextRecord`, `getContentHashRecord`, `getAbiRecord`, `getWrapperData`, `getSupportedInterfaces` and `getAvailable` now accept an optional `blockNumber` for historical reads, matching viem's `CallParameters['blockNumber']`. For `getRecords`, `getName`, `getAddressRecord`, `getTextRecord`, `getContentHashRecord` and `getAbiRecord` - which resolve through the ENS Universal Resolver's `resolve()`/`reverse()` - `blockNumber` only pins the on-chain call: CCIP-read/offchain gateway data (e.g. wildcard-resolved names) is not pinned, since viem's `call` action doesn't forward `blockNumber` through its offchain-lookup retry.
+
+`blockNumber` is not currently supported through `batch()`: batching per-item historical reads would silently fall back to the latest block, so passing `blockNumber` to a batched function now throws `FunctionNotBatchableError` instead of quietly ignoring it.

--- a/packages/ensjs/src/functions/public/batch.test.ts
+++ b/packages/ensjs/src/functions/public/batch.test.ts
@@ -2,6 +2,7 @@ import { http, createPublicClient } from 'viem'
 import { mainnet } from 'viem/chains'
 import { describe, expect, it } from 'vitest'
 import { addEnsContracts } from '../../contracts/addEnsContracts.js'
+import { FunctionNotBatchableError } from '../../errors/public.js'
 import {
   deploymentAddresses,
   publicClient,
@@ -64,5 +65,18 @@ describe('batch', () => {
         "nick@ens.domains",
       ]
     `)
+  })
+  it('should throw FunctionNotBatchableError when an item requests a blockNumber', async () => {
+    await expect(
+      batch(
+        publicClient,
+        getText.batch({
+          name: 'with-profile.eth',
+          key: 'description',
+          blockNumber: 1n,
+        }),
+        getAddressRecord.batch({ name: 'with-profile.eth' }),
+      ),
+    ).rejects.toThrow(FunctionNotBatchableError)
   })
 })

--- a/packages/ensjs/src/functions/public/batch.ts
+++ b/packages/ensjs/src/functions/public/batch.ts
@@ -32,6 +32,9 @@ const encode = (
   const rawDataArr: SimpleTransactionRequest[] = items.map(
     ({ args, encode: encodeRef }, i: number) => {
       if (!encodeRef) throw new FunctionNotBatchableError({ functionIndex: i })
+      if ((args[0] as { blockNumber?: bigint } | undefined)?.blockNumber) {
+        throw new FunctionNotBatchableError({ functionIndex: i })
+      }
       return encodeRef(client, ...args)
     },
   )

--- a/packages/ensjs/src/functions/public/getAbiRecord.ts
+++ b/packages/ensjs/src/functions/public/getAbiRecord.ts
@@ -19,6 +19,8 @@ export type GetAbiRecordParameters = Prettify<
   InternalGetAbiParameters & {
     /** Batch gateway URLs to use for resolving CCIP-read requests. */
     gatewayUrls?: string[]
+    /** Block number to execute the read at, for historical reads */
+    blockNumber?: bigint
   }
 >
 

--- a/packages/ensjs/src/functions/public/getAbiRecord.ts
+++ b/packages/ensjs/src/functions/public/getAbiRecord.ts
@@ -19,7 +19,7 @@ export type GetAbiRecordParameters = Prettify<
   InternalGetAbiParameters & {
     /** Batch gateway URLs to use for resolving CCIP-read requests. */
     gatewayUrls?: string[]
-    /** Block number to execute the read at, for historical reads */
+    /** Block number to execute the read at, for historical reads. Only pins on-chain reads - does not pin CCIP-read/offchain gateway data (e.g. wildcard-resolved names), since viem's `call` action does not forward `blockNumber` through its offchain-lookup retry. */
     blockNumber?: bigint
   }
 >

--- a/packages/ensjs/src/functions/public/getAddressRecord.ts
+++ b/packages/ensjs/src/functions/public/getAddressRecord.ts
@@ -19,7 +19,7 @@ export type GetAddressRecordParameters = Prettify<
   InternalGetAddrParameters & {
     /** Batch gateway URLs to use for resolving CCIP-read requests. */
     gatewayUrls?: string[]
-    /** Block number to execute the read at, for historical reads */
+    /** Block number to execute the read at, for historical reads. Only pins on-chain reads - does not pin CCIP-read/offchain gateway data (e.g. wildcard-resolved names), since viem's `call` action does not forward `blockNumber` through its offchain-lookup retry. */
     blockNumber?: bigint
   }
 >

--- a/packages/ensjs/src/functions/public/getAddressRecord.ts
+++ b/packages/ensjs/src/functions/public/getAddressRecord.ts
@@ -19,6 +19,8 @@ export type GetAddressRecordParameters = Prettify<
   InternalGetAddrParameters & {
     /** Batch gateway URLs to use for resolving CCIP-read requests. */
     gatewayUrls?: string[]
+    /** Block number to execute the read at, for historical reads */
+    blockNumber?: bigint
   }
 >
 

--- a/packages/ensjs/src/functions/public/getAvailable.ts
+++ b/packages/ensjs/src/functions/public/getAvailable.ts
@@ -19,6 +19,8 @@ import { getNameType } from '../../utils/getNameType.js'
 export type GetAvailableParameters = {
   /** Name to check availability for, only compatible for eth 2ld */
   name: string
+  /** Block number to execute the read at, for historical reads */
+  blockNumber?: bigint
 }
 
 export type GetAvailableReturnType = boolean

--- a/packages/ensjs/src/functions/public/getContentHashRecord.ts
+++ b/packages/ensjs/src/functions/public/getContentHashRecord.ts
@@ -19,7 +19,7 @@ export type GetContentHashRecordParameters = Prettify<
   InternalGetContentHashParameters & {
     /** Batch gateway URLs to use for resolving CCIP-read requests. */
     gatewayUrls?: string[]
-    /** Block number to execute the read at, for historical reads */
+    /** Block number to execute the read at, for historical reads. Only pins on-chain reads - does not pin CCIP-read/offchain gateway data (e.g. wildcard-resolved names), since viem's `call` action does not forward `blockNumber` through its offchain-lookup retry. */
     blockNumber?: bigint
   }
 >

--- a/packages/ensjs/src/functions/public/getContentHashRecord.ts
+++ b/packages/ensjs/src/functions/public/getContentHashRecord.ts
@@ -19,6 +19,8 @@ export type GetContentHashRecordParameters = Prettify<
   InternalGetContentHashParameters & {
     /** Batch gateway URLs to use for resolving CCIP-read requests. */
     gatewayUrls?: string[]
+    /** Block number to execute the read at, for historical reads */
+    blockNumber?: bigint
   }
 >
 

--- a/packages/ensjs/src/functions/public/getExpiry.ts
+++ b/packages/ensjs/src/functions/public/getExpiry.ts
@@ -35,6 +35,8 @@ export type GetExpiryParameters = Prettify<{
   name: string
   /** Optional specific contract to use to get expiry */
   contract?: ContractOption
+  /** Block number to execute the read at, for historical reads */
+  blockNumber?: bigint
 }>
 
 export type GetExpiryReturnType = Prettify<{

--- a/packages/ensjs/src/functions/public/getName.ts
+++ b/packages/ensjs/src/functions/public/getName.ts
@@ -64,6 +64,8 @@ export type GetNameParameters = {
   strict?: boolean
   /** Batch gateway URLs to use for resolving CCIP-read requests. */
   gatewayUrls?: string[]
+  /** Block number to execute the read at, for historical reads */
+  blockNumber?: bigint
   // biome-ignore lint/complexity/noBannedTypes: empty object represents no additional parameters in discriminated union
 } & (GetNameCoinTypeParameters | GetNameChainIdParameters | {})
 

--- a/packages/ensjs/src/functions/public/getName.ts
+++ b/packages/ensjs/src/functions/public/getName.ts
@@ -64,7 +64,7 @@ export type GetNameParameters = {
   strict?: boolean
   /** Batch gateway URLs to use for resolving CCIP-read requests. */
   gatewayUrls?: string[]
-  /** Block number to execute the read at, for historical reads */
+  /** Block number to execute the read at, for historical reads. Only pins on-chain reads - does not pin CCIP-read/offchain gateway data (e.g. wildcard-resolved names), since viem's `call` action does not forward `blockNumber` through its offchain-lookup retry. */
   blockNumber?: bigint
   // biome-ignore lint/complexity/noBannedTypes: empty object represents no additional parameters in discriminated union
 } & (GetNameCoinTypeParameters | GetNameChainIdParameters | {})

--- a/packages/ensjs/src/functions/public/getOwner.test.ts
+++ b/packages/ensjs/src/functions/public/getOwner.test.ts
@@ -1,9 +1,15 @@
-import { describe, expect, it } from 'vitest'
+import { numberToHex } from 'viem'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   deploymentAddresses,
   publicClient,
 } from '../../test/addTestContracts.js'
 import getOwner from './getOwner.js'
+
+type RequestArguments = {
+  method: string
+  params?: readonly unknown[]
+}
 
 describe('getOwner', () => {
   it('should return correct ownership level and values for a wrapped .eth name', async () => {
@@ -83,6 +89,32 @@ describe('getOwner', () => {
           "ownershipLevel": "nameWrapper",
         }
       `)
+    })
+  })
+
+  describe('blockNumber', () => {
+    afterEach(() => {
+      vi.restoreAllMocks()
+    })
+
+    it('should thread blockNumber through to the underlying eth_call', async () => {
+      const blockNumber = await publicClient.getBlockNumber()
+      const requestSpy = vi.spyOn(publicClient, 'request') as unknown as {
+        mock: { calls: [RequestArguments][] }
+      }
+
+      const result = await getOwner(publicClient, {
+        name: 'test123.eth',
+        blockNumber,
+      })
+      expect(result).toBeTruthy()
+
+      const ethCallInvocation = requestSpy.mock.calls.find(
+        ([{ method }]) => method === 'eth_call',
+      )
+      expect(ethCallInvocation).toBeDefined()
+      const [{ params }] = ethCallInvocation!
+      expect(params?.[1]).toBe(numberToHex(blockNumber))
     })
   })
 })

--- a/packages/ensjs/src/functions/public/getOwner.ts
+++ b/packages/ensjs/src/functions/public/getOwner.ts
@@ -24,6 +24,8 @@ export type GetOwnerParameters<
   name: string
   /** Optional specific contract to get ownership value from */
   contract?: TContract
+  /** Block number to execute the read at, for historical reads */
+  blockNumber?: bigint
 }
 
 type BaseGetOwnerReturnType = {

--- a/packages/ensjs/src/functions/public/getPrice.test.ts
+++ b/packages/ensjs/src/functions/public/getPrice.test.ts
@@ -1,8 +1,14 @@
-import { describe, expect, it } from 'vitest'
+import { numberToHex } from 'viem'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { publicClient } from '../../test/addTestContracts.js'
 import getPrice from './getPrice.js'
 
 const yearCost = BigInt('8561643835626')
+
+type RequestArguments = {
+  method: string
+  params?: readonly unknown[]
+}
 
 describe('getPrice', () => {
   it('should return a base and premium price for a name', async () => {
@@ -42,5 +48,32 @@ describe('getPrice', () => {
       expect(base).toBe(yearCost)
       expect(premium).toBe(0n)
     }
+  })
+
+  describe('blockNumber', () => {
+    afterEach(() => {
+      vi.restoreAllMocks()
+    })
+
+    it('should thread blockNumber through to the underlying eth_call', async () => {
+      const blockNumber = await publicClient.getBlockNumber()
+      const requestSpy = vi.spyOn(publicClient, 'request') as unknown as {
+        mock: { calls: [RequestArguments][] }
+      }
+
+      const result = await getPrice(publicClient, {
+        nameOrNames: 'test123.eth',
+        duration: 86400,
+        blockNumber,
+      })
+      expect(result).toBeTruthy()
+
+      const ethCallInvocation = requestSpy.mock.calls.find(
+        ([{ method }]) => method === 'eth_call',
+      )
+      expect(ethCallInvocation).toBeDefined()
+      const [{ params }] = ethCallInvocation!
+      expect(params?.[1]).toBe(numberToHex(blockNumber))
+    })
   })
 })

--- a/packages/ensjs/src/functions/public/getPrice.ts
+++ b/packages/ensjs/src/functions/public/getPrice.ts
@@ -22,6 +22,8 @@ export type GetPriceParameters = {
   nameOrNames: string | string[]
   /** Duration in seconds to get price for */
   duration: bigint | number
+  /** Block number to execute the read at, for historical reads */
+  blockNumber?: bigint
 }
 
 export type GetPriceReturnType = {

--- a/packages/ensjs/src/functions/public/getRecords.ts
+++ b/packages/ensjs/src/functions/public/getRecords.ts
@@ -63,7 +63,7 @@ export type GetRecordsParameters<
   }
   /** Batch gateway URLs to use for resolving CCIP-read requests. */
   gatewayUrls?: string[]
-  /** Block number to execute the read at, for historical reads */
+  /** Block number to execute the read at, for historical reads. Only pins on-chain reads - does not pin CCIP-read/offchain gateway data (e.g. wildcard-resolved names), since viem's `call` action does not forward `blockNumber` through its offchain-lookup retry. */
   blockNumber?: bigint
 }
 

--- a/packages/ensjs/src/functions/public/getRecords.ts
+++ b/packages/ensjs/src/functions/public/getRecords.ts
@@ -63,6 +63,8 @@ export type GetRecordsParameters<
   }
   /** Batch gateway URLs to use for resolving CCIP-read requests. */
   gatewayUrls?: string[]
+  /** Block number to execute the read at, for historical reads */
+  blockNumber?: bigint
 }
 
 type WithContentHashResult = {

--- a/packages/ensjs/src/functions/public/getResolver.test.ts
+++ b/packages/ensjs/src/functions/public/getResolver.test.ts
@@ -1,13 +1,45 @@
-import { describe, expect, it } from 'vitest'
+import { numberToHex } from 'viem'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   deploymentAddresses,
   publicClient,
 } from '../../test/addTestContracts.js'
 import getResolver from './getResolver.js'
 
+type RequestArguments = {
+  method: string
+  params?: readonly unknown[]
+}
+
 describe('getResolver', () => {
   it('should find the resolver for a name with a resolver', async () => {
     const result = await getResolver(publicClient, { name: 'with-profile.eth' })
     expect(result).toBe(deploymentAddresses.LegacyPublicResolver)
+  })
+
+  describe('blockNumber', () => {
+    afterEach(() => {
+      vi.restoreAllMocks()
+    })
+
+    it('should thread blockNumber through to the underlying eth_call', async () => {
+      const blockNumber = await publicClient.getBlockNumber()
+      const requestSpy = vi.spyOn(publicClient, 'request') as unknown as {
+        mock: { calls: [RequestArguments][] }
+      }
+
+      const result = await getResolver(publicClient, {
+        name: 'with-profile.eth',
+        blockNumber,
+      })
+      expect(result).toBe(deploymentAddresses.LegacyPublicResolver)
+
+      const ethCallInvocation = requestSpy.mock.calls.find(
+        ([{ method }]) => method === 'eth_call',
+      )
+      expect(ethCallInvocation).toBeDefined()
+      const [{ params }] = ethCallInvocation!
+      expect(params?.[1]).toBe(numberToHex(blockNumber))
+    })
   })
 })

--- a/packages/ensjs/src/functions/public/getResolver.ts
+++ b/packages/ensjs/src/functions/public/getResolver.ts
@@ -24,6 +24,8 @@ import { packetToBytes } from '../../utils/hexEncodedName.js'
 export type GetResolverParameters = {
   /** Name to get resolver for */
   name: string
+  /** Block number to execute the read at, for historical reads */
+  blockNumber?: bigint
 }
 
 export type GetResolverReturnType = Address | null

--- a/packages/ensjs/src/functions/public/getSupportedInterfaces.ts
+++ b/packages/ensjs/src/functions/public/getSupportedInterfaces.ts
@@ -19,6 +19,8 @@ export type GetSupportedInterfacesParameters<
 > = {
   address: Address
   interfaces: TInterfaces
+  /** Block number to execute the read at, for historical reads */
+  blockNumber?: bigint
 }
 
 export type GetSupportedInterfacesReturnType<

--- a/packages/ensjs/src/functions/public/getTextRecord.ts
+++ b/packages/ensjs/src/functions/public/getTextRecord.ts
@@ -19,6 +19,8 @@ export type GetTextRecordParameters = Prettify<
   InternalGetTextParameters & {
     /** Batch gateway URLs to use for resolving CCIP-read requests. */
     gatewayUrls?: string[]
+    /** Block number to execute the read at, for historical reads */
+    blockNumber?: bigint
   }
 >
 

--- a/packages/ensjs/src/functions/public/getTextRecord.ts
+++ b/packages/ensjs/src/functions/public/getTextRecord.ts
@@ -19,7 +19,7 @@ export type GetTextRecordParameters = Prettify<
   InternalGetTextParameters & {
     /** Batch gateway URLs to use for resolving CCIP-read requests. */
     gatewayUrls?: string[]
-    /** Block number to execute the read at, for historical reads */
+    /** Block number to execute the read at, for historical reads. Only pins on-chain reads - does not pin CCIP-read/offchain gateway data (e.g. wildcard-resolved names), since viem's `call` action does not forward `blockNumber` through its offchain-lookup retry. */
     blockNumber?: bigint
   }
 >

--- a/packages/ensjs/src/functions/public/getWrapperData.ts
+++ b/packages/ensjs/src/functions/public/getWrapperData.ts
@@ -27,6 +27,8 @@ import { namehash } from '../../utils/normalise.js'
 export type GetWrapperDataParameters = {
   /** Name to get wrapper data for */
   name: string
+  /** Block number to execute the read at, for historical reads */
+  blockNumber?: bigint
 }
 
 export type GetWrapperDataReturnType = Prettify<{

--- a/packages/ensjs/src/utils/generateFunction.ts
+++ b/packages/ensjs/src/utils/generateFunction.ts
@@ -69,7 +69,8 @@ export const generateFunction = <
 }) => {
   const single = (async (client, ...args) => {
     const { passthrough, ...encodedData } = encode(client, ...args)
-    const result = await call(client, encodedData)
+    const { blockNumber } = (args[0] as { blockNumber?: bigint }) ?? {}
+    const result = await call(client, { ...encodedData, blockNumber })
       .then((ret) => ret.data)
       .catch((e) => {
         if (!(e instanceof BaseError)) throw e


### PR DESCRIPTION
closes #121

The ~13 public read functions in `packages/ensjs/src/functions/public/` (e.g.
`getRecords`, `getOwner`, `getResolver`, `getName`, ...) didn't accept a
`blockNumber` parameter for historical reads, even though the underlying
plumbing already supports it: `generateFunction.ts` calls viem's `call()`
action, which natively takes `blockNumber`.

## Implementation

Added an optional `blockNumber?: bigint` to each `GetXParameters` type.
`generateFunction.ts`'s `single()` reads `blockNumber` generically off the
calling function's own params object and forwards it to viem's `call()` -
none of the 13 functions' own `encode()` bodies needed touching. Zero-risk
when omitted (`blockTag` still defaults to `'latest'`, matching current
behavior exactly).

3 tests cover functions with meaningfully different call shapes -
`getPrice` (plain direct call), `getOwner` (multicall-wrapped, 2-label `.eth`
name), `getResolver` (direct `universalResolver.findResolver` call) - each
spying on `publicClient.request` and asserting `blockNumber` reaches the
actual `eth_call` wire params, not just that it type-checks.

## batch() doesn't support blockNumber, and now says so explicitly

`batch()` flattens multiple sub-calls into a single multicall `eth_call`, so a
batched item's own `blockNumber` can never be honored the way the direct-call
path honors it - the generic pickup only reads the top-level call's args, not
each batched item's nested args. Caught in review before this shipped as a
silent trap: `getOwner.batch({ name, blockNumber })` used to type-check and
silently fall back to `latest`, exactly the kind of "you think you're getting
historical data but you're not" gap this feature exists to close. Now throws
the existing `FunctionNotBatchableError` per-item instead - matches the
pattern this repo already uses for functions that can't be batched at all.
Leaves the door open for real batch-level `blockNumber` support later, without
shipping a silent wrong-answer in the meantime.

## `blockNumber` doesn't pin CCIP-read / offchain-gateway data

Of the 13 functions, 6 route through the Universal Resolver's
`resolve()`/`reverse()` and can trigger CCIP-read for offchain/wildcard names:
`getRecords`, `getName`, `getAddressRecord`, `getTextRecord`,
`getContentHashRecord`, `getAbiRecord`. For these, `blockNumber` only pins the
initial on-chain call - viem's `call` action's offchain-lookup retry doesn't
forward `blockNumber` to the verification call (a pre-existing viem behavior,
not something to fix here). Documented on the JSDoc for exactly those 6
functions - the other 7 (`getOwner`, `getPrice`, `getAvailable`, `getExpiry`,
`getResolver`, `getSupportedInterfaces`, `getWrapperData`) call
registry/registrar/wrapper/price-oracle contracts directly or `findResolver`
(a plain view function, not `resolve()`), so they can never hit CCIP-read and
don't carry the caveat.

`getWrapperName.ts` exists in the same directory but isn't exported from
`public.ts`'s barrel, so it's outside the public surface this PR touches.

## Testing

Typecheck identical to a pre-change baseline (confirmed via `git stash` diff,
zero new errors). Lint (biome) clean on all touched files. Scoped test run
(the 3 representative functions plus batch.ts): 14/16 and the new batch guard
test both pass; 2 pre-existing unrelated snapshot mismatches in
`getOwner.test.ts` reproduce identically with source changes stashed, confirming
they predate this change. Full suite: 76/79 across all 14 touched functions'
test files pass; the 3 failures are the same 2 pre-existing `getOwner`
snapshot mismatches plus one timezone-sensitive `getWrapperData` boundary test
(`Date.getFullYear() === 275760`) in code this PR never touches (only its
params type gained a field, not its decode logic).

Worked around a stuck local Docker daemon by running a bare `anvil` process
directly (matching this repo's `docker compose` entrypoint) instead of the
full test-env stack, so all the above ran against a real chain, not mocks.

Changeset added (`@ensdomains/ensjs`, minor).
