### PR TITLE
fix(dnssec): bump dnsprovejs to 0.5.4, fixing silent failure of DNSSEC proof fetch

### DIFF
--- a/packages/ensjs/package.json
+++ b/packages/ensjs/package.json
@@ -123,7 +123,7 @@
   },
   "devDependencies": {
     "@ensdomains/buffer": "^0.1.3",
-    "@ensdomains/dnsprovejs": "^0.5.2",
+    "@ensdomains/dnsprovejs": "^0.5.4",
     "@ensdomains/ens-test-env": "^1.0.1",
     "@openzeppelin/contracts": "^4.5.0",
     "@types/dns-packet": "^5.6.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,8 +74,8 @@ importers:
         specifier: ^0.1.3
         version: 0.1.3
       '@ensdomains/dnsprovejs':
-        specifier: ^0.5.2
-        version: 0.5.2
+        specifier: ^0.5.4
+        version: 0.5.4
       '@ensdomains/ens-test-env':
         specifier: ^1.0.1
         version: 1.0.1
@@ -321,8 +321,8 @@ packages:
   '@ensdomains/content-hash@3.1.0-rc.1':
     resolution: {integrity: sha512-OzdkXgdFmduzcJKU4KRkkJkQHnm5p7m7FkX8k+bHOEoOIzc0ueGT/Jay4nnb60wNk1wSHRmzY+hHBMpFDiGReg==}
 
-  '@ensdomains/dnsprovejs@0.5.2':
-    resolution: {integrity: sha512-lSuYnUvUV+kBviQ82XUldtpiE0lA4gWrCilsoCWbTKtc/fH6re9NaTkhbPEy/7OF96MMAG1BDnuoTsfSMAzFBg==}
+  '@ensdomains/dnsprovejs@0.5.4':
+    resolution: {integrity: sha512-M7dfCF6OE119s9QYsZowp6ZD9/DGNoALQjB9zxXrjNx7mAZaypZG8Td5fpaDDTmBo0wsHC3GhEtZ+BMUbTArFw==}
     engines: {node: '>=16.8'}
 
   '@ensdomains/ens-test-env@1.0.1':
@@ -2214,7 +2214,7 @@ snapshots:
       '@noble/curves': 1.9.7
       '@scure/base': 1.2.6
 
-  '@ensdomains/dnsprovejs@0.5.2':
+  '@ensdomains/dnsprovejs@0.5.4':
     dependencies:
       '@noble/hashes': 1.8.0
       dns-packet: 5.6.1


### PR DESCRIPTION
# Bump @ensdomains/dnsprovejs to ^0.5.4

Versions 0.5.1-0.5.3 send pre-RFC-8484 DoH requests that modern resolvers (Cloudflare, Google, Quad9) reject, causing dnsprovejs to mis-decode the resulting HTTP error page as a DNS response.

Fixed upstream in [dnsprovejs PR #53](https://github.com/ensdomains/dnsprovejs/pull/53), which was rolled into `v0.5.4`

## Testing

- `pnpm -r build`: all 5 buildable projects build clean.
- `pnpm -F @ensdomains/ensjs test` :
  507 passed, 5 skipped, 65.2s. `getDnsOwner.test.ts` 14/14.
  `getDnsImportData.test.ts` 1/1 - hits live DoH resolvers, log confirms
  the RRSIG/DNSKEY chain verifying root -> `xyz` -> `taytems.xyz` ->
  `_ens.taytems.xyz` TXT.
