### PR TITLE
refactor: correct JSDoc entrypoints and drop redundant V2 suffixes

### DIFF
--- a/packages/ensjs/src/actions/public/registrar/getAvailable.ts
+++ b/packages/ensjs/src/actions/public/registrar/getAvailable.ts
@@ -55,7 +55,7 @@ export type GetAvailableErrorType =
  * import { createPublicClient, http } from 'viem'
  * import { mainnet } from 'viem/chains'
  * import { addEnsContracts } from '@ensdomains/ensjs'
- * import { getAvailable } from '@ensdomains/ensjs/public/v2'
+ * import { getAvailable } from '@ensdomains/ensjs/public'
  *
  * const client = createPublicClient({
  *   chain: addEnsContracts(mainnet),

--- a/packages/ensjs/src/actions/public/registrar/getRenewPrice.ts
+++ b/packages/ensjs/src/actions/public/registrar/getRenewPrice.ts
@@ -39,7 +39,7 @@ export type GetRenewPriceErrorType = ReadContractErrorType | TypeError
  * @returns Renewal price in `paymentToken` units. {@link GetRenewPriceReturnType}
  *
  * @example
- * import { getRenewPrice } from '@ensdomains/ensjs/public/v2'
+ * import { getRenewPrice } from '@ensdomains/ensjs/public'
  *
  * const price = await getRenewPrice(client, {
  *   renewerAddress: '0x...',

--- a/packages/ensjs/src/actions/public/registrar/isRenewable.ts
+++ b/packages/ensjs/src/actions/public/registrar/isRenewable.ts
@@ -33,7 +33,7 @@ export type IsRenewableErrorType = ReadContractErrorType | TypeError
  * @returns `true` if the label is currently renewable. {@link IsRenewableReturnType}
  *
  * @example
- * import { isRenewable } from '@ensdomains/ensjs/public/v2'
+ * import { isRenewable } from '@ensdomains/ensjs/public'
  *
  * const renewable = await isRenewable(client, {
  *   renewerAddress: '0x...',

--- a/packages/ensjs/src/actions/public/v1/nameWrapper/getWrapperData.ts
+++ b/packages/ensjs/src/actions/public/v1/nameWrapper/getWrapperData.ts
@@ -50,7 +50,7 @@ export type GetWrapperDataErrorType =
  * import { createPublicClient, http } from 'viem'
  * import { mainnet } from 'viem/chains'
  * import { addEnsContracts } from '@ensdomains/ensjs'
- * import { getWrapperData } from '@ensdomains/ensjs/public'
+ * import { getWrapperData } from '@ensdomains/ensjs/public/v1'
  *
  * const client = createPublicClient({
  *   chain: addEnsContracts(mainnet),

--- a/packages/ensjs/src/actions/public/v1/nameWrapper/getWrapperName.ts
+++ b/packages/ensjs/src/actions/public/v1/nameWrapper/getWrapperName.ts
@@ -44,7 +44,7 @@ export type GetWrapperNameErrorType =
  * import { createPublicClient, http } from 'viem'
  * import { mainnet } from 'viem/chains'
  * import { addEnsContracts } from '@ensdomains/ensjs'
- * import { getWrapperName } from '@ensdomains/ensjs/public'
+ * import { getWrapperName } from '@ensdomains/ensjs/public/v1'
  *
  * const client = createPublicClient({
  *   chain: addEnsContracts(mainnet),

--- a/packages/ensjs/src/actions/public/v1/registrar/getExpiry.ts
+++ b/packages/ensjs/src/actions/public/v1/registrar/getExpiry.ts
@@ -58,7 +58,7 @@ export type GetExpiryErrorType =
  * import { createPublicClient, http } from 'viem'
  * import { mainnet } from 'viem/chains'
  * import { addEnsContracts } from '@ensdomains/ensjs'
- * import { getExpiry } from '@ensdomains/ensjs/public'
+ * import { getExpiry } from '@ensdomains/ensjs/public/v1'
  *
  * const client = createPublicClient({
  *   chain: addEnsContracts(mainnet),

--- a/packages/ensjs/src/actions/public/v1/registry/getOwner.ts
+++ b/packages/ensjs/src/actions/public/v1/registry/getOwner.ts
@@ -94,7 +94,7 @@ export type GetOwnerErrorType =
  * import { createPublicClient, http } from 'viem'
  * import { mainnet } from 'viem/chains'
  * import { addEnsContracts } from '@ensdomains/ensjs'
- * import { getOwner } from '@ensdomains/ensjs/public'
+ * import { getOwner } from '@ensdomains/ensjs/public/v1'
  *
  * const client = createPublicClient({
  *   chain: addEnsContracts(mainnet),

--- a/packages/ensjs/src/actions/public/v1/registry/getReverseRecordFromRegistry.ts
+++ b/packages/ensjs/src/actions/public/v1/registry/getReverseRecordFromRegistry.ts
@@ -49,7 +49,7 @@ export type GetReverseRecordFromRegistryErrorType =
  * import { createPublicClient, http } from 'viem'
  * import { mainnet } from 'viem/chains'
  * import { addEnsContracts } from '@ensdomains/ensjs'
- * import { getReverseRecordFromRegistry } from '@ensdomains/ensjs/public'
+ * import { getReverseRecordFromRegistry } from '@ensdomains/ensjs/public/v1'
  *
  * const client = createPublicClient({
  *   chain: addEnsContracts(mainnet),

--- a/packages/ensjs/src/actions/public/v2/registry/getSubregistryHistory.ts
+++ b/packages/ensjs/src/actions/public/v2/registry/getSubregistryHistory.ts
@@ -35,7 +35,7 @@ export type GetSubregistryHistoryErrorType = GetLogsErrorType
  * @example
  * import { createPublicClient, http } from 'viem'
  * import { mainnet } from 'viem/chains'
- * import { getSubregistryHistory } from '@ensdomains/ensjs/public'
+ * import { getSubregistryHistory } from '@ensdomains/ensjs/public/v2'
  *
  * const client = createPublicClient({
  *   chain: mainnet,

--- a/packages/ensjs/src/actions/wallet/registrar/registerName.ts
+++ b/packages/ensjs/src/actions/wallet/registrar/registerName.ts
@@ -130,7 +130,7 @@ export type RegisterNameErrorType =
  * import { createPublicClient, createWalletClient, http, custom } from 'viem'
  * import { mainnet } from 'viem/chains'
  * import { addEnsContracts } from '@ensdomains/ensjs'
- * import { getPrice } from '@ensdomains/ensjs/public/v1'
+ * import { getPrice } from '@ensdomains/ensjs/wallet'
  * import { randomSecret } from '@ensdomains/ensjs/utils'
  * import { commitName, registerName } from '@ensdomains/ensjs/wallet'
  *

--- a/packages/ensjs/src/actions/wallet/v1/nameWrapper/setChildFuses.ts
+++ b/packages/ensjs/src/actions/wallet/v1/nameWrapper/setChildFuses.ts
@@ -110,7 +110,7 @@ export type SetChildFusesErrorType =
  * import { createWalletClient, custom } from 'viem'
  * import { mainnet } from 'viem/chains'
  * import { addEnsContracts } from '@ensdomains/ensjs'
- * import { setChildFuses } from '@ensdomains/ensjs/wallet'
+ * import { setChildFuses } from '@ensdomains/ensjs/wallet/v1'
  *
  * const wallet = createWalletClient({
  *   chain: addEnsContracts(mainnet),

--- a/packages/ensjs/src/actions/wallet/v1/nameWrapper/setFuses.ts
+++ b/packages/ensjs/src/actions/wallet/v1/nameWrapper/setFuses.ts
@@ -93,7 +93,7 @@ export type SetFusesErrorType = Error
  * import { createWalletClient, custom } from 'viem'
  * import { mainnet } from 'viem/chains'
  * import { addEnsContracts } from '@ensdomains/ensjs'
- * import { setFuses } from '@ensdomains/ensjs/wallet'
+ * import { setFuses } from '@ensdomains/ensjs/wallet/v1'
  *
  * const wallet = createWalletClient({
  *   chain: addEnsContracts(mainnet),

--- a/packages/ensjs/src/actions/wallet/v1/nameWrapper/unwrapName.ts
+++ b/packages/ensjs/src/actions/wallet/v1/nameWrapper/unwrapName.ts
@@ -149,7 +149,7 @@ export type UnwrapNameErrorType =
  * import { createWalletClient, custom } from 'viem'
  * import { mainnet } from 'viem/chains'
  * import { addEnsContracts } from '@ensdomains/ensjs'
- * import { unwrapName } from '@ensdomains/ensjs/wallet'
+ * import { unwrapName } from '@ensdomains/ensjs/wallet/v1'
  *
  * const wallet = createWalletClient({
  *   chain: addEnsContracts(mainnet),

--- a/packages/ensjs/src/actions/wallet/v1/nameWrapper/wrapName.ts
+++ b/packages/ensjs/src/actions/wallet/v1/nameWrapper/wrapName.ts
@@ -182,7 +182,7 @@ export type WrapNameErrorType =
  * import { createWalletClient, custom } from 'viem'
  * import { mainnet } from 'viem/chains'
  * import { addEnsContracts } from '@ensdomains/ensjs'
- * import { wrapName } from '@ensdomains/ensjs/wallet'
+ * import { wrapName } from '@ensdomains/ensjs/wallet/v1'
  *
  * const wallet = createWalletClient({
  *   chain: addEnsContracts(mainnet),

--- a/packages/ensjs/src/actions/wallet/v1/registry/createSubname.ts
+++ b/packages/ensjs/src/actions/wallet/v1/registry/createSubname.ts
@@ -293,7 +293,7 @@ export type CreateSubnameErrorType =
  * import { createWalletClient, custom } from 'viem'
  * import { mainnet } from 'viem/chains'
  * import { addEnsContracts } from '@ensdomains/ensjs'
- * import { createSubname } from '@ensdomains/ensjs/wallet'
+ * import { createSubname } from '@ensdomains/ensjs/wallet/v1'
  *
  * const wallet = createWalletClient({
  *   chain: addEnsContracts(mainnet),

--- a/packages/ensjs/src/actions/wallet/v1/registry/deleteSubname.ts
+++ b/packages/ensjs/src/actions/wallet/v1/registry/deleteSubname.ts
@@ -195,7 +195,7 @@ export type DeleteSubnameErrorType =
  * import { createWalletClient, custom } from 'viem'
  * import { mainnet } from 'viem/chains'
  * import { addEnsContracts } from '@ensdomains/ensjs'
- * import { deleteSubname } from '@ensdomains/ensjs/wallet'
+ * import { deleteSubname } from '@ensdomains/ensjs/wallet/v1'
  *
  * const wallet = createWalletClient({
  *   chain: mainnetWithEns,

--- a/packages/ensjs/src/actions/wallet/v1/registry/setResolver.ts
+++ b/packages/ensjs/src/actions/wallet/v1/registry/setResolver.ts
@@ -128,7 +128,7 @@ export type SetResolverErrorType =
  * import { createWalletClient, custom } from 'viem'
  * import { mainnet } from 'viem/chains'
  * import { addEnsContracts } from '@ensdomains/ensjs'
- * import { setResolver } from '@ensdomains/ensjs/wallet'
+ * import { setResolver } from '@ensdomains/ensjs/wallet/v1'
  *
  * const wallet = createWalletClient({
  *   chain: addEnsContracts(mainnet),

--- a/packages/ensjs/src/actions/wallet/v1/registry/transferName.ts
+++ b/packages/ensjs/src/actions/wallet/v1/registry/transferName.ts
@@ -261,7 +261,7 @@ export type TransferNameErrorType =
  * import { createWalletClient, custom } from 'viem'
  * import { mainnet } from 'viem/chains'
  * import { addEnsContracts } from '@ensdomains/ensjs'
- * import { transferName } from '@ensdomains/ensjs/wallet'
+ * import { transferName } from '@ensdomains/ensjs/wallet/v1'
  *
  * const wallet = createWalletClient({
  *   chain: addEnsContracts(mainnet),

--- a/packages/ensjs/src/actions/wallet/v1/resolver/clearRecords.ts
+++ b/packages/ensjs/src/actions/wallet/v1/resolver/clearRecords.ts
@@ -90,7 +90,7 @@ export type ClearRecordsErrorType =
  * import { createWalletClient, custom } from 'viem'
  * import { mainnet } from 'viem/chains'
  * import { addEnsContracts } from '@ensdomains/ensjs'
- * import { clearRecords } from '@ensdomains/ensjs/wallet'
+ * import { clearRecords } from '@ensdomains/ensjs/wallet/v1'
  *
  * const wallet = createWalletClient({
  *   chain: addEnsContracts(mainnet),

--- a/packages/ensjs/src/actions/wallet/v1/resolver/setRecords.ts
+++ b/packages/ensjs/src/actions/wallet/v1/resolver/setRecords.ts
@@ -119,7 +119,7 @@ export type SetRecordsErrorType =
  * import { createWalletClient, custom } from 'viem'
  * import { mainnet } from 'viem/chains'
  * import { addEnsContracts } from '@ensdomains/ensjs'
- * import { setRecords } from '@ensdomains/ensjs/wallet'
+ * import { setRecords } from '@ensdomains/ensjs/wallet/v1'
  *
  * const wallet = createWalletClient({
  *   chain: addEnsContracts(mainnet),

--- a/packages/ensjs/src/actions/wallet/v1/reverseRegistrar/setPrimaryName.ts
+++ b/packages/ensjs/src/actions/wallet/v1/reverseRegistrar/setPrimaryName.ts
@@ -144,7 +144,7 @@ export type SetPrimaryNameErrorType =
  * import { createWalletClient, custom } from 'viem'
  * import { mainnet } from 'viem/chains'
  * import { addEnsContracts } from '@ensdomains/ensjs'
- * import { setPrimaryName } from '@ensdomains/ensjs/wallet'
+ * import { setPrimaryName } from '@ensdomains/ensjs/wallet/v1'
  *
  * const wallet = createWalletClient({
  *   chain: addEnsContracts(mainnet),

--- a/packages/ensjs/src/actions/wallet/v2/accessControl/revokeRoles.ts
+++ b/packages/ensjs/src/actions/wallet/v2/accessControl/revokeRoles.ts
@@ -119,7 +119,7 @@ export type RevokeRolesErrorType =
  * import { createWalletClient, custom } from 'viem'
  * import { mainnet } from 'viem/chains'
  * import { addEnsContracts } from '@ensdomains/ensjs'
- * import { revokeRoles } from '@ensdomains/ensjs/wallet'
+ * import { revokeRoles } from '@ensdomains/ensjs/wallet/v2'
  *
  * const wallet = createWalletClient({
  *   chain: addEnsContracts(mainnet),

--- a/packages/ensjs/src/actions/wallet/v2/registry/createSubname.ts
+++ b/packages/ensjs/src/actions/wallet/v2/registry/createSubname.ts
@@ -42,11 +42,11 @@ export type CreateSubnameWriteParametersParameters = {
   expires?: bigint
 }
 
-export type CreateSubnameV2WriteParametersReturnType = ReturnType<
-  typeof createSubnameV2WriteParameters
+export type CreateSubnameWriteParametersReturnType = ReturnType<
+  typeof createSubnameWriteParameters
 >
 
-export const createSubnameV2WriteParameters = <
+export const createSubnameWriteParameters = <
   chain extends Chain,
   account extends Account,
 >(
@@ -89,7 +89,7 @@ export const createSubnameV2WriteParameters = <
 // Action
 // ================================
 
-export type CreateSubnameV2Parameters<
+export type CreateSubnameParameters<
   chain extends Chain,
   account extends Account,
   chainOverride extends Chain | undefined,
@@ -98,28 +98,28 @@ export type CreateSubnameV2Parameters<
     WriteTransactionParameters<chain, account, chainOverride>
 >
 
-export type CreateSubnameV2ReturnType = Hash
+export type CreateSubnameReturnType = Hash
 
-export type CreateSubnameV2ErrorType =
+export type CreateSubnameErrorType =
   | ClientWithOverridesErrorType
   | WriteContractErrorType
 
 /**
  * Creates a subname in a UserRegistry using the register function (V2).
  * @param client - {@link Client}
- * @param parameters - {@link CreateSubnameV2Parameters}
- * @returns Transaction hash. {@link CreateSubnameV2ReturnType}
+ * @param parameters - {@link CreateSubnameParameters}
+ * @returns Transaction hash. {@link CreateSubnameReturnType}
  *
  * @example
  * import { createWalletClient, custom } from 'viem'
  * import { mainnet } from 'viem/chains'
- * import { createSubnameV2 } from '@ensdomains/ensjs/wallet/v2'
+ * import { createSubname } from '@ensdomains/ensjs/wallet/v2'
  *
  * const wallet = createWalletClient({
  *   chain: mainnet,
  *   transport: custom(window.ethereum),
  * })
- * const hash = await createSubnameV2(wallet, {
+ * const hash = await createSubname(wallet, {
  *   registryAddress: '0x...', // parent registry
  *   label: 'mysubname',
  *   owner: '0x...',
@@ -130,7 +130,7 @@ export type CreateSubnameV2ErrorType =
  * })
  * // 0x...
  */
-export async function createSubnameV2<
+export async function createSubname<
   chain extends Chain,
   account extends Account,
   chainOverride extends Chain | undefined,
@@ -145,11 +145,11 @@ export async function createSubnameV2<
     roleBitmap,
     expires,
     ...txArgs
-  }: CreateSubnameV2Parameters<chain, account, chainOverride>,
-): Promise<CreateSubnameV2ReturnType> {
+  }: CreateSubnameParameters<chain, account, chainOverride>,
+): Promise<CreateSubnameReturnType> {
   ASSERT_NO_TYPE_ERROR(client)
 
-  const writeParameters = createSubnameV2WriteParameters(
+  const writeParameters = createSubnameWriteParameters(
     clientWithOverrides(client, txArgs),
     {
       registryAddress,

--- a/packages/ensjs/src/actions/wallet/v2/registry/createSubname.ts
+++ b/packages/ensjs/src/actions/wallet/v2/registry/createSubname.ts
@@ -113,7 +113,7 @@ export type CreateSubnameV2ErrorType =
  * @example
  * import { createWalletClient, custom } from 'viem'
  * import { mainnet } from 'viem/chains'
- * import { createSubnameV2 } from '@ensdomains/ensjs/wallet'
+ * import { createSubnameV2 } from '@ensdomains/ensjs/wallet/v2'
  *
  * const wallet = createWalletClient({
  *   chain: mainnet,

--- a/packages/ensjs/src/actions/wallet/v2/registry/deleteSubname.ts
+++ b/packages/ensjs/src/actions/wallet/v2/registry/deleteSubname.ts
@@ -97,7 +97,7 @@ export type DeleteSubnameErrorType =
  * @example
  * import { createWalletClient, custom } from 'viem'
  * import { mainnet } from 'viem/chains'
- * import { deleteSubname } from '@ensdomains/ensjs/wallet'
+ * import { deleteSubname } from '@ensdomains/ensjs/wallet/v2'
  *
  * const wallet = createWalletClient({
  *   chain: mainnet,

--- a/packages/ensjs/src/actions/wallet/v2/registry/deleteSubnames.ts
+++ b/packages/ensjs/src/actions/wallet/v2/registry/deleteSubnames.ts
@@ -71,7 +71,7 @@ export type DeleteSubnamesErrorType =
  * @example
  * import { createWalletClient, custom } from 'viem'
  * import { mainnet } from 'viem/chains'
- * import { deleteSubnames } from '@ensdomains/ensjs/wallet'
+ * import { deleteSubnames } from '@ensdomains/ensjs/wallet/v2'
  *
  * const wallet = createWalletClient({
  *   chain: mainnet,

--- a/packages/ensjs/src/actions/wallet/v2/registry/setResolver.ts
+++ b/packages/ensjs/src/actions/wallet/v2/registry/setResolver.ts
@@ -94,7 +94,7 @@ export type SetResolverErrorType =
  * @example
  * import { createWalletClient, custom } from 'viem'
  * import { mainnet } from 'viem/chains'
- * import { setResolver } from '@ensdomains/ensjs/wallet'
+ * import { setResolver } from '@ensdomains/ensjs/wallet/v2'
  *
  * const wallet = createWalletClient({
  *   chain: mainnet,

--- a/packages/ensjs/src/actions/wallet/v2/registry/setSubregistry.ts
+++ b/packages/ensjs/src/actions/wallet/v2/registry/setSubregistry.ts
@@ -94,7 +94,7 @@ export type SetSubregistryErrorType =
  * @example
  * import { createWalletClient, custom } from 'viem'
  * import { mainnet } from 'viem/chains'
- * import { setSubregistry } from '@ensdomains/ensjs/wallet'
+ * import { setSubregistry } from '@ensdomains/ensjs/wallet/v2'
  *
  * const wallet = createWalletClient({
  *   chain: mainnet,

--- a/packages/ensjs/src/actions/wallet/v2/resolver/deleteAlias.ts
+++ b/packages/ensjs/src/actions/wallet/v2/resolver/deleteAlias.ts
@@ -89,7 +89,7 @@ export type DeleteAliasErrorType =
  * @example
  * import { createWalletClient, custom } from 'viem'
  * import { mainnet } from 'viem/chains'
- * import { deleteAlias } from '@ensdomains/ensjs/wallet'
+ * import { deleteAlias } from '@ensdomains/ensjs/wallet/v2'
  *
  * const wallet = createWalletClient({
  *   chain: mainnet,

--- a/packages/ensjs/src/actions/wallet/v2/resolver/setAlias.ts
+++ b/packages/ensjs/src/actions/wallet/v2/resolver/setAlias.ts
@@ -92,7 +92,7 @@ export type SetAliasErrorType =
  * @example
  * import { createWalletClient, custom } from 'viem'
  * import { mainnet } from 'viem/chains'
- * import { setAlias } from '@ensdomains/ensjs/wallet'
+ * import { setAlias } from '@ensdomains/ensjs/wallet/v2'
  *
  * const wallet = createWalletClient({
  *   chain: mainnet,

--- a/packages/ensjs/src/actions/wallet/v2/verifiableFactory/deploySubregistry.ts
+++ b/packages/ensjs/src/actions/wallet/v2/verifiableFactory/deploySubregistry.ts
@@ -128,7 +128,7 @@ export type DeploySubregistryErrorType =
  * import { createWalletClient, custom } from 'viem'
  * import { mainnet } from 'viem/chains'
  * import { addEnsContracts } from '@ensdomains/ensjs'
- * import { deploySubregistry } from '@ensdomains/ensjs/wallet'
+ * import { deploySubregistry } from '@ensdomains/ensjs/wallet/v2'
  *
  * const wallet = createWalletClient({
  *   chain: addEnsContracts(mainnet),

--- a/packages/ensjs/src/actions/wallet/v2/verifiableFactory/deployVerifiableProxy.ts
+++ b/packages/ensjs/src/actions/wallet/v2/verifiableFactory/deployVerifiableProxy.ts
@@ -137,7 +137,7 @@ export type DeployVerifiableProxyErrorType =
  * import { createWalletClient, custom } from 'viem'
  * import { mainnet } from 'viem/chains'
  * import { addEnsContracts } from '@ensdomains/ensjs'
- * import { deployVerifiableProxy } from '@ensdomains/ensjs/wallet'
+ * import { deployVerifiableProxy } from '@ensdomains/ensjs/wallet/v2'
  *
  * const wallet = createWalletClient({
  *   chain: addEnsContracts(mainnet),


### PR DESCRIPTION
Stacked on #370, on top of the now-merged #371. Two follow-ups that only became possible once the entrypoints were split.

## 1. JSDoc examples named the wrong entrypoints

Every action's `@example` block shows the import a consumer should write, and these strings feed typedoc — they are the docs people actually read. **31 of them named an entrypoint that no longer exports the action:**

- v2 registry and resolver writes still said `/wallet` → now `/wallet/v2`
- registrar reads and the rent price oracle still said `/public/v2` → now `/public`
- v1 reads still said `/public` → now `/public/v1`

Corrected by deriving each example from the barrel that actually exports the module, rather than by hand.

Some of these were wrong before any of this work — the v1 reads have been telling people to import `getWrapperData` from `/public` while it lived on `/public/v1`. The re-cut just made the drift measurable.

## 2. The `V2` suffixes are now redundant

`createSubnameV2`, `CreateSubnameV2Parameters`, `CreateSubnameV2ReturnType`, `CreateSubnameV2ErrorType`, `createSubnameV2WriteParameters` and `CreateSubnameV2WriteParametersReturnType` were named that way for exactly one reason: `/wallet` exported both the v1 and v2 subname actions, so the two sets of identifiers had to differ.

With `/wallet/v1` and `/wallet/v2` separate, the suffix carries no information — and it made this the only module in the tree whose symbols didn't match its action name. The file already contained an unsuffixed `CreateSubnameWriteParametersParameters`, so it was internally inconsistent as well.

```
createSubnameV2                          -> createSubname
CreateSubnameV2Parameters                -> CreateSubnameParameters
CreateSubnameV2ReturnType                -> CreateSubnameReturnType
CreateSubnameV2ErrorType                 -> CreateSubnameErrorType
createSubnameV2WriteParameters           -> createSubnameWriteParameters
CreateSubnameV2WriteParametersReturnType -> CreateSubnameWriteParametersReturnType
```

This was the last of the `V2`-suffixed identifiers — no other module used the pattern, and nothing outside the module referenced these names, so no downstream changes were needed.

## Verification

| Check | Result |
| --- | --- |
| `pnpm check:types` | clean |
| `pnpm lint` | exit 0 |
| `pnpm build` | exit 0 |
| react build | 85 errors — unchanged from `main` |
| query-core build | 44 errors — unchanged from `main` |

No changeset: `main` is still on `5.0.0-alpha.1` and isn't being released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CjwdKmGPKVv5iM2bDvtCTA