### PR TITLE
refactor!: replace graphql-request with a plain fetch subgraph client

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,4 +137,4 @@ export const actionName = async (
 - `@adraffy/ens-normalize` - Name normalization
 - `@ensdomains/address-encoder` - Address encoding
 - `@ensdomains/content-hash` - Content hash encoding
-- `graphql-request` - Subgraph queries
+- `graphql` (optional peer dependency `^16.0.0 || ^17.0.0`) - Parsing/printing subgraph queries; only needed by the `/subgraph` entrypoint, whose client is otherwise plain `fetch`

--- a/packages/ensjs/package.json
+++ b/packages/ensjs/package.json
@@ -136,8 +136,6 @@
     "@ensdomains/content-hash": "3.1.0-rc.1",
     "@ensdomains/ensjs-abi": "workspace:*",
     "dns-packet": "^5.3.1",
-    "graphql": "^16.11.0",
-    "graphql-request": "7.2.0",
     "ts-pattern": "^5.4.0"
   },
   "devDependencies": {
@@ -149,6 +147,7 @@
     "@types/node": "^22.15.14",
     "@types/pako": "^2.0.3",
     "@vitest/coverage-v8": "^3.2.6",
+    "graphql": "^16.11.0",
     "pako": "^2.1.0",
     "typedoc": "^0.24.8",
     "typedoc-plugin-markdown": "^4.0.0-next.16",
@@ -156,7 +155,13 @@
     "vitest": "^3.2.6"
   },
   "peerDependencies": {
+    "graphql": "^16.0.0 || ^17.0.0",
     "viem": "^2.9.2"
+  },
+  "peerDependenciesMeta": {
+    "graphql": {
+      "optional": true
+    }
   },
   "engines": {
     "node": ">=22"

--- a/packages/ensjs/src/actions/subgraph/client.test.ts
+++ b/packages/ensjs/src/actions/subgraph/client.test.ts
@@ -1,6 +1,11 @@
 import { namehash } from 'viem/ens'
-import { describe, expect, it } from 'vitest'
-import { requestMiddleware, responseMiddleware } from './client.js'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { SubgraphRequestError } from '../../errors/subgraph.js'
+import {
+  createSubgraphClient,
+  hashInvalidNames,
+  injectIdSelections,
+} from './client.js'
 
 const queryWithoutId = `
 query getNames($id: ID!, $expiryDate: Int) {
@@ -31,14 +36,6 @@ query getNames($id: ID!, $expiryDate: Int) {
     }
   }
 `
-
-const mockRequest = {
-  method: 'POST',
-  headers: {
-    'Content-Type': 'application/json',
-  },
-  body: JSON.stringify({ query: queryWithoutId }),
-}
 
 const mockResponse = {
   data: {
@@ -148,22 +145,131 @@ const mockResponse = {
   status: 200,
 }
 
-describe('requestMiddleware', () => {
+describe('injectIdSelections', () => {
   it('should add id to a SelectionSet if name is present and id is not', () => {
-    const result = requestMiddleware(mockRequest as any)
-    const body = (result as any).body as string
-    expect(body.match(/domain.*id.*id.*domains.*id.*id/)?.length).toBe(1)
+    const result = injectIdSelections(queryWithoutId).replace(/\s+/g, ' ')
+    expect(result).toContain('parent { name id }')
+  })
+
+  it('should not add id to a SelectionSet that already selects it', () => {
+    const query = 'query { domain { id name } }'
+    const result = injectIdSelections(query).replace(/\s+/g, ' ')
+    expect(result).toContain('domain { id name }')
+  })
+
+  it('should leave a SelectionSet without name alone', () => {
+    const query = 'query { domain { labelhash createdAt } }'
+    const result = injectIdSelections(query).replace(/\s+/g, ' ')
+    expect(result).toContain('domain { labelhash createdAt }')
   })
 })
 
-describe('responseMiddleware', () => {
+describe('hashInvalidNames', () => {
   it('should replace name with the namehash when there is an invalid name and id combo', () => {
     const response = { ...mockResponse }
-    responseMiddleware(response as any, {} as any)
+    hashInvalidNames(response.data)
     expect(response.data.account.domains[0].name).toBe(
       namehash(
         '0xb54c7c79c89d571f1fbf4c67f524e336a04441eeee4d76f156e835da99a46ddb',
       ),
+    )
+  })
+})
+
+describe('createSubgraphClient', () => {
+  const client = createSubgraphClient({
+    chain: { subgraphs: { ens: { url: 'http://localhost:8000/subgraph' } } },
+  })
+
+  const stubFetch = (body: string, status = 200) => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(body, {
+          status,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+    return fetchMock
+  }
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('should post the query and variables, with ids injected', async () => {
+    const fetchMock = stubFetch(JSON.stringify({ data: { domain: null } }))
+
+    await client.request(
+      'query getDomain($id: String!) { domain(id: $id) { name } }',
+      {
+        id: '0x123',
+      },
+    )
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [
+      string,
+      RequestInit,
+    ]
+    expect(url).toBe('http://localhost:8000/subgraph')
+    expect(init.method).toBe('POST')
+    expect(new Headers(init.headers).get('Content-Type')).toBe(
+      'application/json',
+    )
+
+    const body = JSON.parse(init.body as string)
+    expect(body.variables).toEqual({ id: '0x123' })
+    expect(body.query.replace(/\s+/g, ' ')).toContain(
+      'domain(id: $id) { name id }',
+    )
+  })
+
+  it('should return the data payload, with invalid names hashed', async () => {
+    stubFetch(
+      JSON.stringify({
+        data: {
+          domain: {
+            id: '0x0000000000000000000000000000000000000000000000000000000000000001',
+            name: 'test.eth',
+          },
+        },
+      }),
+    )
+
+    const result = await client.request<{
+      domain: { name: string; invalidName?: boolean }
+    }>('query { domain { id name } }')
+
+    expect(result.domain.name).toBe(namehash('test.eth'))
+    expect(result.domain.invalidName).toBe(true)
+  })
+
+  it('should throw when the response carries GraphQL errors', async () => {
+    stubFetch(
+      JSON.stringify({
+        errors: [{ message: 'Field "nope" not found', path: ['domain'] }],
+      }),
+    )
+
+    await expect(client.request('query { domain { nope } }')).rejects.toThrow(
+      SubgraphRequestError,
+    )
+  })
+
+  it('should throw when the response status is not ok', async () => {
+    stubFetch(JSON.stringify({ data: null }), 502)
+
+    await expect(client.request('query { domain { name } }')).rejects.toThrow(
+      /status 502/,
+    )
+  })
+
+  it('should throw when the response is not JSON', async () => {
+    stubFetch('<html>bad gateway</html>', 200)
+
+    await expect(client.request('query { domain { name } }')).rejects.toThrow(
+      /not valid JSON/,
     )
   })
 })

--- a/packages/ensjs/src/actions/subgraph/client.ts
+++ b/packages/ensjs/src/actions/subgraph/client.ts
@@ -1,9 +1,24 @@
 import type { Kind, SelectionNode, SelectionSetNode } from 'graphql'
 import { parse, print, visit } from 'graphql/language/index.js'
-import type { RequestMiddleware, ResponseMiddleware } from 'graphql-request'
-import { GraphQLClient } from 'graphql-request'
 import { namehash } from 'viem/ens'
 import type { ChainWithSubgraph } from '../../clients/l1.js'
+import {
+  type SubgraphGraphQLError,
+  SubgraphRequestError,
+} from '../../errors/subgraph.js'
+
+export type SubgraphVariables = Record<string, unknown>
+
+export type SubgraphClient = {
+  /** Endpoint that queries are sent to */
+  url: string
+  /** Sends a query to the subgraph, returning the `data` payload */
+  request: <TResult, TVariables extends SubgraphVariables = SubgraphVariables>(
+    query: string,
+    variables?: TVariables,
+    requestHeaders?: HeadersInit,
+  ) => Promise<TResult>
+}
 
 const generateSelection = (selection: string): SelectionNode => ({
   kind: 'Field' as Kind.FIELD,
@@ -37,24 +52,24 @@ const enter = (node: SelectionSetNode) => {
   return undefined
 }
 
-export const requestMiddleware: RequestMiddleware = (request) => {
-  if (!request.body) return request
-  const requestBody = JSON.parse(request.body as string)
-  const rawQuery = requestBody.query as string
-  const parsedQuery = parse(rawQuery)
-  const updatedQuery = visit(parsedQuery, {
-    SelectionSet: {
-      enter,
-    },
-  })
+/**
+ * Adds `id` to any selection set that asks for `name` without it, so that
+ * {@link hashInvalidNames} can check each returned name against its namehash.
+ */
+export const injectIdSelections = (query: string): string =>
+  print(
+    visit(parse(query), {
+      SelectionSet: {
+        enter,
+      },
+    }),
+  )
 
-  return {
-    ...request,
-    body: JSON.stringify({ ...requestBody, query: print(updatedQuery) }),
-  }
-}
-
-export const responseMiddleware: ResponseMiddleware = (response, _options) => {
+/**
+ * Replaces any `name` that doesn't hash to its own `id` with the namehash of
+ * that name, flagging it as `invalidName`. Mutates the data in place.
+ */
+export const hashInvalidNames = (data: unknown) => {
   const traverse = (obj: Record<string, any>) => {
     if (obj && typeof obj === 'object') {
       for (const key in obj) {
@@ -93,13 +108,76 @@ export const responseMiddleware: ResponseMiddleware = (response, _options) => {
     }
   }
 
-  traverse(response)
+  traverse(data as Record<string, any>)
+}
+
+type SubgraphResponseBody<TResult> = {
+  data?: TResult
+  errors?: SubgraphGraphQLError[]
+}
+
+const executeRequest = async <
+  TResult,
+  TVariables extends SubgraphVariables = SubgraphVariables,
+>(
+  url: string,
+  query: string,
+  variables?: TVariables,
+  requestHeaders?: HeadersInit,
+): Promise<TResult> => {
+  const headers = new Headers(requestHeaders)
+  headers.set('Content-Type', 'application/json')
+  headers.set('Accept', 'application/json')
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ query: injectIdSelections(query), variables }),
+  })
+
+  const text = await response.text()
+
+  let body: SubgraphResponseBody<TResult>
+  try {
+    body = JSON.parse(text)
+  } catch (_e) {
+    throw new SubgraphRequestError({
+      status: response.status,
+      details: `Response was not valid JSON: ${text.slice(0, 512)}`,
+    })
+  }
+
+  if (!response.ok || body.errors?.length)
+    throw new SubgraphRequestError({
+      status: response.status,
+      errors: body.errors ?? [],
+    })
+
+  hashInvalidNames(body.data)
+
+  return body.data as TResult
 }
 
 export const createSubgraphClient = <_chain extends ChainWithSubgraph>(client: {
   chain: _chain
-}) =>
-  new GraphQLClient(client.chain.subgraphs.ens.url, {
-    requestMiddleware,
-    responseMiddleware,
-  })
+}): SubgraphClient => {
+  const { url } = client.chain.subgraphs.ens
+
+  return {
+    url,
+    request: <
+      TResult,
+      TVariables extends SubgraphVariables = SubgraphVariables,
+    >(
+      query: string,
+      variables?: TVariables,
+      requestHeaders?: HeadersInit,
+    ) =>
+      executeRequest<TResult, TVariables>(
+        url,
+        query,
+        variables,
+        requestHeaders,
+      ),
+  }
+}

--- a/packages/ensjs/src/actions/subgraph/fragments.ts
+++ b/packages/ensjs/src/actions/subgraph/fragments.ts
@@ -1,5 +1,5 @@
-import { gql } from 'graphql-request'
 import type { Address, Hex } from 'viem'
+import { gql } from './gql.js'
 
 export const domainDetailsWithoutParentFragment = gql`
   fragment DomainDetailsWithoutParent on Domain {

--- a/packages/ensjs/src/actions/subgraph/getDecodedName.ts
+++ b/packages/ensjs/src/actions/subgraph/getDecodedName.ts
@@ -1,4 +1,3 @@
-import { gql } from 'graphql-request'
 import { namehash } from 'viem/ens'
 import type { ChainWithSubgraph } from '../../clients/l1.js'
 import {
@@ -7,6 +6,7 @@ import {
   isEncodedLabelhash,
 } from '../../utils/name/labels.js'
 import { createSubgraphClient } from './client.js'
+import { gql } from './gql.js'
 
 export type GetDecodedNameParameters = {
   /** Name with unknown labels */

--- a/packages/ensjs/src/actions/subgraph/getNameHistory.ts
+++ b/packages/ensjs/src/actions/subgraph/getNameHistory.ts
@@ -1,4 +1,3 @@
-import { gql } from 'graphql-request'
 import { namehash } from 'viem/ens'
 import type { ChainWithSubgraph } from '../../clients/l1.js'
 import { createSubgraphClient } from './client.js'
@@ -10,6 +9,7 @@ import type {
   RegistrationEvent,
   ResolverEvent,
 } from './events.js'
+import { gql } from './gql.js'
 import { decodeResolverEvents } from './utils.js'
 
 export type GetNameHistoryParameters = {

--- a/packages/ensjs/src/actions/subgraph/getNamesForAddress.ts
+++ b/packages/ensjs/src/actions/subgraph/getNamesForAddress.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import { gql } from 'graphql-request'
+
 import type { Address } from 'viem'
 import type { ChainWithSubgraph } from '../../clients/l1.js'
 import {
@@ -20,6 +20,7 @@ import {
   type SubgraphDomain,
   wrappedDomainDetailsFragment,
 } from './fragments.js'
+import { gql } from './gql.js'
 import { makeNameObject, type Name } from './utils.js'
 
 export type GetNamesForAddressParameters = {

--- a/packages/ensjs/src/actions/subgraph/getRecordHistory.ts
+++ b/packages/ensjs/src/actions/subgraph/getRecordHistory.ts
@@ -1,9 +1,9 @@
-import { gql } from 'graphql-request'
 import { namehash } from 'viem'
 import type { ChainWithSubgraph } from '../../clients/l1.js'
 import { createSubgraphClient } from './client.js'
 import type { ResolverEvent } from './events.js'
 import type { ReturnResolverEvent } from './getNameHistory.js'
+import { gql } from './gql.js'
 import { decodeResolverEvents } from './utils.js'
 
 type SubgraphResult = {

--- a/packages/ensjs/src/actions/subgraph/getSubgraphRecords.ts
+++ b/packages/ensjs/src/actions/subgraph/getSubgraphRecords.ts
@@ -1,10 +1,10 @@
-import type { GraphQLClient } from 'graphql-request'
-import { gql } from 'graphql-request'
 import type { Address, Hex } from 'viem'
 import { namehash } from 'viem/ens'
 import type { ChainWithSubgraph } from '../../clients/l1.js'
 import type { DateWithValue } from '../../types/index.js'
+import type { SubgraphClient } from './client.js'
 import { createSubgraphClient } from './client.js'
+import { gql } from './gql.js'
 
 export type GetSubgraphRecordsParameters = {
   /** Name to get records for */
@@ -82,7 +82,7 @@ type GetResolverResultReturnType = {
 } | null
 
 const getCustomResolverResult = async (
-  subgraphClient: GraphQLClient,
+  subgraphClient: SubgraphClient,
   {
     id,
     resolverAddress,
@@ -107,7 +107,7 @@ const getCustomResolverResult = async (
 }
 
 const getInheritedResolverResult = async (
-  subgraphClient: GraphQLClient,
+  subgraphClient: SubgraphClient,
   {
     id,
   }: {

--- a/packages/ensjs/src/actions/subgraph/getSubgraphRegistrant.ts
+++ b/packages/ensjs/src/actions/subgraph/getSubgraphRegistrant.ts
@@ -1,9 +1,9 @@
-import { gql } from 'graphql-request'
 import { type Address, getAddress, namehash } from 'viem'
 import type { ChainWithSubgraph } from '../../clients/l1.js'
 import { UnsupportedNameTypeError } from '../../errors/general.js'
 import { getNameType } from '../../utils/name/getNameType.js'
 import { createSubgraphClient } from './client.js'
+import { gql } from './gql.js'
 
 export type GetSubgraphRegistrantParameters = {
   /** Name to get registrant for */

--- a/packages/ensjs/src/actions/subgraph/getSubnames.ts
+++ b/packages/ensjs/src/actions/subgraph/getSubnames.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import { gql } from 'graphql-request'
+
 import { namehash } from 'viem/ens'
 import type { ChainWithSubgraph } from '../../clients/l1.js'
 import { InvalidOrderByError } from '../../errors/subgraph.js'
@@ -16,6 +16,7 @@ import {
   type SubgraphDomain,
   wrappedDomainDetailsFragment,
 } from './fragments.js'
+import { gql } from './gql.js'
 import { makeNameObject, type Name } from './utils.js'
 
 export type GetSubnamesParameters = {

--- a/packages/ensjs/src/actions/subgraph/gql.ts
+++ b/packages/ensjs/src/actions/subgraph/gql.ts
@@ -1,0 +1,17 @@
+/**
+ * Passthrough template tag for GraphQL documents. Unlike `graphql-tag` this
+ * does not parse the input into a `DocumentNode` — it just interpolates the
+ * template and returns the string, which is all the subgraph client needs.
+ *
+ * It exists purely so that editors, formatters and linters — which key off a
+ * template tag literally named `gql` — keep highlighting these queries.
+ */
+export const gql = (
+  chunks: TemplateStringsArray,
+  ...variables: unknown[]
+): string =>
+  chunks.reduce(
+    (acc, chunk, index) =>
+      `${acc}${chunk}${index in variables ? String(variables[index]) : ''}`,
+    '',
+  )

--- a/packages/ensjs/src/errors/subgraph.ts
+++ b/packages/ensjs/src/errors/subgraph.ts
@@ -69,3 +69,44 @@ export class InvalidOrderByError extends BaseError {
     this.supportedOrderBys = supportedOrderBys
   }
 }
+
+export type SubgraphGraphQLError = {
+  message: string
+  locations?: { line: number; column: number }[]
+  path?: (string | number)[]
+  extensions?: Record<string, unknown>
+}
+
+export class SubgraphRequestError extends BaseError {
+  status: number
+
+  errors: SubgraphGraphQLError[]
+
+  override name = 'SubgraphRequestError'
+
+  constructor({
+    status,
+    errors = [],
+    details,
+  }: {
+    status: number
+    errors?: SubgraphGraphQLError[]
+    details?: string
+  }) {
+    super(
+      errors.length
+        ? 'Subgraph query returned errors'
+        : `Subgraph request failed with status ${status}`,
+      {
+        metaMessages: errors.length
+          ? errors.map(({ message, path }) =>
+              path?.length ? `- ${path.join('.')}: ${message}` : `- ${message}`,
+            )
+          : undefined,
+        details,
+      },
+    )
+    this.status = status
+    this.errors = errors
+  }
+}

--- a/packages/ensjs/src/index.ts
+++ b/packages/ensjs/src/index.ts
@@ -25,6 +25,8 @@ export {
   FilterKeyRequiredError,
   InvalidFilterKeyError,
   InvalidOrderByError,
+  type SubgraphGraphQLError,
+  SubgraphRequestError,
 } from './errors/subgraph.js'
 export {
   CampaignReferenceTooLargeError,

--- a/packages/ensjs/src/subgraph.ts
+++ b/packages/ensjs/src/subgraph.ts
@@ -1,4 +1,8 @@
-export { createSubgraphClient } from './actions/subgraph/client.js'
+export {
+  createSubgraphClient,
+  type SubgraphClient,
+  type SubgraphVariables,
+} from './actions/subgraph/client.js'
 export type {
   AbiChanged,
   AddrChanged,

--- a/packages/ensjs/vitest.config.ts
+++ b/packages/ensjs/vitest.config.ts
@@ -1,7 +1,10 @@
 import { defineConfig } from 'vitest/config'
 
 // Shared excludes for all projects.
-const baseExclude = ['data/**/*', 'src/actions/subgraph/**/*.test.ts']
+// The subgraph action tests need a live ENSNode instance, so they stay out of
+// both projects. `client.test.ts` next to them is pure logic (query rewriting,
+// name hashing, a stubbed fetch) and runs in the parallel project below.
+const baseExclude = ['data/**/*', 'src/actions/subgraph/get*.test.ts']
 
 // Pure-logic tests: encoders/coders, name utils, fuses/roles, content hash,
 // formatting, CCIP helpers, and a couple of actions that only exercise encoding
@@ -15,6 +18,7 @@ const baseExclude = ['data/**/*', 'src/actions/subgraph/**/*.test.ts']
 // sequentially, in one project (fileParallelism: false).
 const pureLogicTests = [
   'src/utils/**/*.test.ts',
+  'src/actions/subgraph/client.test.ts',
   'src/actions/dns/getDnsOwner.test.ts',
   'src/actions/public/getNames.test.ts',
   'src/actions/public/resolveNameData.test.ts',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,12 +60,6 @@ importers:
       dns-packet:
         specifier: ^5.3.1
         version: 5.6.1
-      graphql:
-        specifier: ^16.11.0
-        version: 16.13.2
-      graphql-request:
-        specifier: 7.2.0
-        version: 7.2.0(graphql@16.13.2)
       ts-pattern:
         specifier: ^5.4.0
         version: 5.9.0
@@ -94,6 +88,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^3.2.6
         version: 3.2.6(vitest@3.2.6(@types/node@22.19.17)(yaml@2.8.3))
+      graphql:
+        specifier: ^16.11.0
+        version: 16.13.2
       pako:
         specifier: ^2.1.0
         version: 2.1.0
@@ -485,11 +482,6 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
-
-  '@graphql-typed-document-node/core@3.2.0':
-    resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
-    peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
 
   '@hapi/address@5.1.1':
     resolution: {integrity: sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==}
@@ -1257,11 +1249,6 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
-
-  graphql-request@7.2.0:
-    resolution: {integrity: sha512-0GR7eQHBFYz372u9lxS16cOtEekFlZYB2qOyq8wDvzRmdRSJ0mgUVX1tzNcIzk3G+4NY+mGtSz411wZdeDF/+A==}
-    peerDependencies:
-      graphql: 14 - 16
 
   graphql@16.13.2:
     resolution: {integrity: sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==}
@@ -2316,10 +2303,6 @@ snapshots:
   '@esbuild/win32-x64@0.27.7':
     optional: true
 
-  '@graphql-typed-document-node/core@3.2.0(graphql@16.13.2)':
-    dependencies:
-      graphql: 16.13.2
-
   '@hapi/address@5.1.1':
     dependencies:
       '@hapi/hoek': 11.0.7
@@ -3014,11 +2997,6 @@ snapshots:
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
-
-  graphql-request@7.2.0(graphql@16.13.2):
-    dependencies:
-      '@graphql-typed-document-node/core': 3.2.0(graphql@16.13.2)
-      graphql: 16.13.2
 
   graphql@16.13.2: {}
 


### PR DESCRIPTION
## Why

`graphql-request` was pulling its weight in name only. Across all of `src/actions/subgraph/` it provided exactly three things:

| Feature | Actual usage |
|---|---|
| `gql` template tag | Pure passthrough. Its own JSDoc: *"has no runtime effect beyond variable interpolation."* |
| `client.request<T>(query, vars)` | POST `{query, variables}`, throw on errors. No batching, no `rawRequest`, no `TypedDocumentNode`, no header juggling. |
| `requestMiddleware` / `responseMiddleware` | Just hooks — the logic inside was already ours. |

Fragments were composed by plain string interpolation, so nothing depended on document nodes either. That's ~40 lines of `fetch` wearing a 12.8 KB gzip dependency.

## What changed

**`createSubgraphClient` now returns a plain object backed by `fetch`:**

```ts
export type SubgraphClient = {
  url: string
  request: <TResult, TVariables extends SubgraphVariables = SubgraphVariables>(
    query: string,
    variables?: TVariables,
    requestHeaders?: HeadersInit,
  ) => Promise<TResult>
}
```

Same `request<TResult, TVars>(query, vars)` shape every call site already used, so all nine actions were untouched apart from their import line.

- **`client.ts`** — the two middleware functions became directly-called helpers with honest names: `injectIdSelections(query)` and `hashInvalidNames(data)`. The `id`-injection and namehash-verification logic is byte-for-byte the same.
- **`gql.ts`** (new) — 3-line passthrough tag, a straight port of graphql-request's own, kept purely so editors and formatters keep highlighting the queries.
- **`errors/subgraph.ts`** — new `SubgraphRequestError extends BaseError` replacing `ClientError`. Carries `status` + `errors[]` and covers three cases: non-2xx, a GraphQL `errors` array, and a non-JSON body (an HTML error page from a proxy now gives a readable message instead of a bare `SyntaxError`).

## graphql is now an optional peer dependency

`graphql` is still needed for `parse`/`print`/`visit`, but it never crosses the public API boundary — it appears in **no emitted `.d.ts`**, so there's no dual-instance hazard. An import-graph trace of the built output shows it's reachable only from `/subgraph`; `index`, `dns`, `public`, `wallet`, `chain`, `utils` and `contracts` never load it. Hence `peerDependenciesMeta.optional`, so the other entrypoints don't drag a parser along or trip `strict-peer-dependencies`.

The range `^16.0.0 || ^17.0.0` is measured, not guessed:

| graphql | runtime | types |
|---|---|---|
| 15.10.3 | ✅ | ❌ `Cannot find namespace 'Kind'` |
| 16.0.0 | ✅ | ✅ |
| 16.14.2 | ✅ | ✅ |
| 17.0.2 | ✅ | ✅ |

`parse`/`print`/`visit` produce byte-identical output on all four. The floor is purely a TypeScript one: `client.ts` writes `'Field' as Kind.FIELD`, which needs `Kind` in type space. graphql 15 declares it as a plain `const` object; it became an enum in 16.0.0, and 17 restructured it into `export * as Kind` while keeping a type alias per kind. The full ensjs source typechecks clean against 17.0.2, deep `graphql/language/index.js` import included (it survives 17's new `exports` map via the `./*.js` wildcard).

## Tests

`client.test.ts` was excluded from vitest by the blanket `src/actions/subgraph/**/*.test.ts` glob — it got swept up with the ENSNode-dependent integration tests, despite being pure logic. The exclude is narrowed to `get*.test.ts` (matching exactly those six files) and `client.test.ts` joins `pureLogicTests`.

Coverage went 2 → 9: the two originals are preserved against the renamed functions, 3 more cover `injectIdSelections` edge cases, and 4 cover the new `fetch` path with a stubbed global — request shape, data + name hashing, GraphQL errors, non-ok status, non-JSON body.

Full suite against the devnet: **89 files, 516 passed, 5 skipped**. Build, typecheck and biome all clean.

## Breaking changes

- `createSubgraphClient()` returns `SubgraphClient`, not `GraphQLClient`. `.request()` keeps its signature including per-request headers, but `.rawRequest()`, `.batchRequests()`, `.setHeader()` and `.setHeaders()` are gone. Nothing in the repo used any of them.
- Failures throw `SubgraphRequestError` (exported from the root) instead of `ClientError`.
- Consumers of `/subgraph` must install `graphql` themselves.

No changeset — not releasing this yet.

## Follow-up worth considering

`graphql/language/index.js` is *larger* than the root import: 13.8 KB gzip vs **10.8 KB**. graphql 16 has no `exports` field, so the deep path resolves to CJS and can't tree-shake, while the root path resolves via `module: index.mjs` and does. Switching would save another ~3 KB gzip and drop the reliance on 17's wildcard. The counter-argument is unbundled Node, where the root import loads the whole library — left alone here since it's orthogonal to removing graphql-request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01An5nyuEX9KXwfRq129uSrD
