### PR TITLE
fix: validate/escape untrusted input in labelhash decoding and DNS lookups

### DIFF
--- a/packages/ensjs/src/actions/subgraph/getDecodedName.ts
+++ b/packages/ensjs/src/actions/subgraph/getDecodedName.ts
@@ -55,14 +55,20 @@ const getDecodedName = async (
 
   const subgraphClient = createSubgraphClient(client)
 
+  // labelhash values are passed as GraphQL variables, never interpolated
+  // into the query string, so a crafted label can't inject additional
+  // query syntax
+  const variables: Record<string, unknown> = { id: namehash(name) }
   let labelsQuery = ''
+  let labelsQueryVariables = ''
   for (let i = 0; i < labels.length; i += 1) {
     const label = labels[i]
     if (isEncodedLabelhash(label)) {
+      const variableName = `labelhash${i}`
+      variables[variableName] = decodeLabelhash(label).toLowerCase()
+      labelsQueryVariables += `, $${variableName}: Bytes`
       labelsQuery += gql`
-        labels${i}: domains(first: 1, where: { labelhash: "${decodeLabelhash(
-          label,
-        ).toLowerCase()}", labelName_not: null }) {
+        labels${i}: domains(first: 1, where: { labelhash: $${variableName}, labelName_not: null }) {
           labelName
         }
       `
@@ -70,7 +76,7 @@ const getDecodedName = async (
   }
 
   const decodedNameQuery = gql`
-    query decodedName($id: String!) {
+    query decodedName($id: String!${labelsQueryVariables}) {
       namehashLookup: domain(id: $id) {
         name
       }
@@ -80,9 +86,7 @@ const getDecodedName = async (
 
   const decodedNameResult = await subgraphClient.request<SubgraphResult>(
     decodedNameQuery,
-    {
-      id: namehash(name),
-    },
+    variables,
   )
   if (!decodedNameResult) return null
 

--- a/packages/ensjs/src/utils/dns/getDnsTxtRecords.test.ts
+++ b/packages/ensjs/src/utils/dns/getDnsTxtRecords.test.ts
@@ -1,0 +1,73 @@
+import type { RequestListener } from 'node:http'
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  expect,
+  it,
+  type MockedFunction,
+  vi,
+} from 'vitest'
+import { createHttpServer } from '../../test/createHttpServer.js'
+import { getDnsTxtRecords } from './getDnsTxtRecords.js'
+
+const handler: MockedFunction<RequestListener> = vi.fn()
+let closeServer: () => Promise<unknown>
+let serverUrl: `http://${string}` = 'http://'
+
+beforeAll(async () => {
+  const { close, url } = await createHttpServer(handler)
+  closeServer = close
+  serverUrl = url
+})
+
+afterAll(async () => {
+  await closeServer()
+})
+
+beforeEach(() => {
+  handler.mockReset()
+})
+
+it('requests the expected name for a plain name', async () => {
+  let receivedParams: URLSearchParams | null = null
+  handler.mockImplementation((req, res) => {
+    receivedParams = new URL(req.url!, `http://${req.headers.host!}`)
+      .searchParams
+    res.writeHead(200, { 'Content-Type': 'application/dns-json' })
+    res.end(JSON.stringify({ Status: 0, AD: true, Answer: [] }))
+    res.destroy()
+  })
+
+  await getDnsTxtRecords({ name: '_ens.example.com', endpoint: serverUrl })
+
+  expect(receivedParams).not.toBeNull()
+  expect(receivedParams!.get('name')).toBe('_ens.example.com.')
+  expect(receivedParams!.get('type')).toBe('TXT')
+  expect(receivedParams!.get('do')).toBe('1')
+  // exactly the three intended params - nothing extra
+  expect([...receivedParams!.keys()]).toEqual(['name', 'type', 'do'])
+})
+
+it('does not let an unescaped name inject extra query parameters', async () => {
+  let receivedParams: URLSearchParams | null = null
+  handler.mockImplementation((req, res) => {
+    receivedParams = new URL(req.url!, `http://${req.headers.host!}`)
+      .searchParams
+    res.writeHead(200, { 'Content-Type': 'application/dns-json' })
+    res.end(JSON.stringify({ Status: 0, AD: true, Answer: [] }))
+    res.destroy()
+  })
+
+  // a name shaped to try to append cd/type params if interpolated unescaped
+  const maliciousName = '_ens.example.com&type=A&cd=1'
+
+  await getDnsTxtRecords({ name: maliciousName, endpoint: serverUrl })
+
+  expect(receivedParams).not.toBeNull()
+  // the whole string lands in `name`, not split into extra params
+  expect([...receivedParams!.keys()]).toEqual(['name', 'type', 'do'])
+  expect(receivedParams!.get('name')).toBe(`${maliciousName}.`)
+  expect(receivedParams!.get('type')).toBe('TXT')
+  expect(receivedParams!.get('do')).toBe('1')
+})

--- a/packages/ensjs/src/utils/dns/getDnsTxtRecords.ts
+++ b/packages/ensjs/src/utils/dns/getDnsTxtRecords.ts
@@ -28,7 +28,7 @@ export const getDnsTxtRecords = async ({
   endpoint = 'https://cloudflare-dns.com/dns-query',
 }: GetDnsTxtRecordsParameters): Promise<GetDnsTxtRecordsReturnType> => {
   const response: DnsResponse = await fetch(
-    `${endpoint}?name=${name}.&type=TXT&do=1`,
+    `${endpoint}?name=${encodeURIComponent(name)}.&type=TXT&do=1`,
     {
       method: 'GET',
       headers: {

--- a/packages/ensjs/src/utils/name/labels.test.ts
+++ b/packages/ensjs/src/utils/name/labels.test.ts
@@ -1,6 +1,7 @@
 import { labelhash } from 'viem'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
+  checkIsDecrypted,
   decodeLabelhash,
   encodeLabelhash,
   isEncodedLabelhash,
@@ -59,6 +60,23 @@ describe('decodeLabelhash()', () => {
       - Supplied label: [9c22ff5f21f0b81b113e63f7db6da94fedef11b2119b4088b89664fb9a3cb65]
 
       Details: Expected encoded labelhash to have a length of 66
+
+      Version: @ensdomains/ensjs@1.0.0-mock.0]
+    `)
+  })
+  it('throws error when decoded content is not valid hex', () => {
+    // 64 chars between the brackets, correct length, but not hex - this is
+    // the shape that let a crafted label reach GraphQL query interpolation
+    // unvalidated (getDecodedName.ts) before this fix
+    const nonHexPayload = `[${'z", labelname_not: null }) { labelname } evil: __typename #'.padEnd(64, ' ')}]`
+    expect(() =>
+      decodeLabelhash(nonHexPayload),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      [InvalidEncodedLabelError: Invalid encoded label
+
+      - Supplied label: [z", labelname_not: null }) { labelname } evil: __typename #     ]
+
+      Details: Expected encoded labelhash to contain a valid hex string
 
       Version: @ensdomains/ensjs@1.0.0-mock.0]
     `)
@@ -159,5 +177,32 @@ describe('saveName()', () => {
       'ensjs:labels',
       JSON.stringify({ [labelhash('eth')]: 'eth' }),
     )
+  })
+})
+
+describe('checkIsDecrypted()', () => {
+  it('returns true for a plain string', () => {
+    expect(checkIsDecrypted('test.eth')).toBe(true)
+  })
+  it('returns false for a string containing an encoded label', () => {
+    expect(
+      checkIsDecrypted(
+        '[9c22ff5f21f0b81b113e63f7db6da94fedef11b2119b4088b89664fb9a3cb658].eth',
+      ),
+    ).toBe(false)
+  })
+  it('returns true for an array of plain labels', () => {
+    expect(checkIsDecrypted(['test', 'eth'])).toBe(true)
+  })
+  it('returns false for an array containing an encoded label', () => {
+    // Array.prototype.includes does exact-element equality, not substring
+    // matching, so this previously fell through to `true` regardless of
+    // content
+    expect(
+      checkIsDecrypted([
+        '[9c22ff5f21f0b81b113e63f7db6da94fedef11b2119b4088b89664fb9a3cb658]',
+        'eth',
+      ]),
+    ).toBe(false)
   })
 })

--- a/packages/ensjs/src/utils/name/labels.ts
+++ b/packages/ensjs/src/utils/name/labels.ts
@@ -1,4 +1,4 @@
-import { type Hex, type LabelhashErrorType, labelhash } from 'viem'
+import { type Hex, isHex, type LabelhashErrorType, labelhash } from 'viem'
 import {
   InvalidEncodedLabelError,
   InvalidLabelhashError,
@@ -33,7 +33,15 @@ export function decodeLabelhash(hash: string): Hex {
       details: 'Expected encoded labelhash to have a length of 66',
     })
 
-  return `0x${hash.slice(1, -1)}`
+  const decoded = `0x${hash.slice(1, -1)}`
+
+  if (!isHex(decoded))
+    throw new InvalidEncodedLabelError({
+      label: hash,
+      details: 'Expected encoded labelhash to contain a valid hex string',
+    })
+
+  return decoded
 }
 
 // ================================
@@ -145,6 +153,7 @@ export function checkLabel(hash: string): string {
 // ================================
 
 export function checkIsDecrypted(string: string | string[]) {
+  if (Array.isArray(string)) return !string.some((s) => s.includes('['))
   return !string?.includes('[')
 }
 


### PR DESCRIPTION
Input-validation hardening in three related spots — a decoder that lies about its own return type, and two places that splice untrusted input into a query string without escaping. Framing this as validation hardening, not a claimed exploit: real-world impact here is query manipulation / degraded DNSSEC posture on read-only public endpoints, not a privilege-escalation path.

## 1. `decodeLabelhash` never validated hex, and the value reached an unescaped GraphQL interpolation

`decodeLabelhash` (`packages/ensjs/src/utils/name/labels.ts`) is declared to return `Hex`, but only checked the brackets and the 66-char length — never that the content between them was actually hex.

`getDecodedName` (`packages/ensjs/src/actions/subgraph/getDecodedName.ts`) spliced that unvalidated value straight into a GraphQL query string via `gql` (`packages/ensjs/src/actions/subgraph/gql.ts`), which is an explicit passthrough template tag with zero escaping (see its own docstring).

**Real repro against the actual `decodeLabelhash`/`gql`/`checkIsDecrypted` from this repo** (crafted a 66-char bracketed, non-hex label that passes the old bracket+length gate, doesn't get short-circuited by `checkIsDecrypted`, and — parsed with the real `graphql` package — injects an additional top-level field into the query):

```
label length: 66 (needs 66)
checkIsDecrypted(label): false (does not short-circuit)

--- Final interpolated query (before fix) ---
    query decodedName($id: String!) {
      namehashLookup: domain(id: $id) { name }
      labels0: domains(first: 1, where: { labelhash: "0xz"}){labelname}evil:domains(where:{labelhash:"z                 ", labelName_not: null }) {
          labelName
        }
    }

--- Parse attempt (real `graphql` package) ---
PARSES OK. top-level selections: [ 'namehashLookup', 'labels0', 'evil' ]
```

Fix: `decodeLabelhash` now runs the decoded value through viem's `isHex` (strict mode) before returning it, so it actually honors its declared `Hex` type. Defense in depth: `getDecodedName` no longer interpolates the labelhash into the query string at all — it's now passed as a real GraphQL variable (`$labelhash0: Bytes`, etc.), so even a future caller that skips `decodeLabelhash`'s validation can't reopen the same injection class.

## 2. `checkIsDecrypted`'s array branch was a no-op

`checkIsDecrypted(string: string | string[])` used `!string.includes('[')`. For an array, `Array.prototype.includes` does exact-element equality, not substring matching, so `['[abc...]', 'eth'].includes('[')` is always `false` — an array containing a bracketed/encrypted label incorrectly reports as fully decrypted. Currently unreachable via the three internal call sites (all pass strings), but the function is exported publicly via `@ensdomains/ensjs/utils` with `string[]` in its signature, so it's a real gap for any external caller who does pass an array.

## 3. `getDnsTxtRecords` interpolated `name` into a DNS-over-HTTPS URL unescaped

`getNameType(name) === 'other-2ld'` (the caller-side gate in e.g. `getDnsOwner.ts`) is a plain `.split('.')` length check that passes strings containing `&`.

**Real repro** (local HTTP server, inspecting the actual request the buggy code sends):
```
name: 'example.com&type=A&cd=1'
buggy URL params:  [name, example.com], [type, A], [cd, "1."], [type, TXT], [do, 1]
fixed URL params:  [name, "example.com&type=A&cd=1."], [type, TXT], [do, 1]
```

Fix: wrap `name` in `encodeURIComponent()`.

## Receipts

**Real test suite (before fix, with only the injection repro test added, confirming it fails against pre-fix code):** the "throws error when decoded content is not valid hex" test asserts the throw the fix introduces — omitted here for brevity since the interesting evidence is the after-state below, but the injection repro above was run standalone against the actual pre-fix `decodeLabelhash` and produced the parsed 3-field injection shown.

**Real test suite, after fix** (`npx vitest run` against `labels.test.ts` + new `getDnsTxtRecords.test.ts`, config with the repo's own `setupFiles` but without the Docker-devnet `globalSetup` these two pure-logic files don't need — see note below):
```
✓ src/utils/dns/getDnsTxtRecords.test.ts (2 tests) 24ms
✓ src/utils/name/labels.test.ts (17 tests) 11ms

Test Files  2 passed (2)
     Tests  19 passed (19)
```

**Typecheck** (`tsc --noEmit`, full package): exit 0, no errors.

**Lint** (`biome check`): 0 errors. Only pre-existing-pattern warnings (`noNonNullAssertion` in the new test file) that already exist identically in the repo's own `getDnsOwner.test.ts` (same `new URL(req.url!, ...)` pattern) — not a new issue introduced here.

**Codex (GPT-5.6) adversarial second-opinion review**, run against the actual diff and this repo's source: *"The exact 66-character check plus strict `isHex` limits decoded content to 64 hex digits, so the old interpolation attack cannot pass validation, and the variables rewrite independently closes injection because only generated variable/alias names enter the query text. Legit inputs retain prior behavior, including lowercase normalization and multiple encoded labels; `Bytes` matches the subgraph filter type. The array fix and URL encoding are correct."* It independently re-ran `tsc --noEmit` itself and confirmed a clean pass.

**Note on local test config:** `src/actions/subgraph/get*.test.ts` (including `getDecodedName.test.ts`) is already excluded from this repo's own `vitest.config.ts` "pure logic" project and needs a live ENSNode devnet — I couldn't spin that up in this environment (local `docker compose` version mismatch on the repo's compose file, unrelated to this change), so `getDecodedName.ts`'s GraphQL-variable rewrite is verified via `tsc --noEmit` + manual query-construction checks (confirmed the rewritten query parses correctly with the real `graphql` package for both zero and multiple encoded labels) rather than that file's own e2e test. Happy to have CI confirm on this PR.
