### PR TITLE
fix: content hash decoding throws on arbitrary on-chain bytes

### DIFF
--- a/packages/ensjs/src/actions/public/resolver/getRecords.ts
+++ b/packages/ensjs/src/actions/public/resolver/getRecords.ts
@@ -211,12 +211,20 @@ const createCalls = <
             shouldDecodeFromPrimitiveTypes: shouldDecodeFromPrimitiveTypes
             data: Hex
           }) => {
-            const result = shouldDecodeFromPrimitiveTypes
-              ? decodeContentHashResultFromPrimitiveTypes({ decodedData: data })
-              : decodeContentHashResult(data, { strict: false })
-            if (!result) return
+            try {
+              const result = shouldDecodeFromPrimitiveTypes
+                ? decodeContentHashResultFromPrimitiveTypes({
+                    decodedData: data,
+                  })
+                : decodeContentHashResult(data, { strict: false })
+              if (!result) return
 
-            currentResult.contentHash = result
+              currentResult.contentHash = result
+            } catch (e) {
+              console.error(e)
+              // Don't panic if coming across an unrecognised content hash codec
+              return
+            }
           },
         },
       ] as const)

--- a/packages/ensjs/src/actions/subgraph/utils.ts
+++ b/packages/ensjs/src/actions/subgraph/utils.ts
@@ -165,9 +165,19 @@ export const decodeResolverEvents = (resolverEvents: ResolverEvent[]) => {
         }
       }
       case 'ContenthashChanged': {
-        const { decoded: contentHash, protocolType } = decodeContentHash(
-          event.hash,
-        ) || { protocolType: null, decoded: null }
+        // decodeContentHash throws for bytes it doesn't recognise as a known
+        // codec - subgraph event data is as unvalidated as onchain data, so
+        // this must degrade to "undecoded" rather than crash the mapper
+        let decodedContentHash: ReturnType<typeof decodeContentHash>
+        try {
+          decodedContentHash = decodeContentHash(event.hash)
+        } catch {
+          decodedContentHash = null
+        }
+        const { decoded: contentHash, protocolType } = decodedContentHash || {
+          protocolType: null,
+          decoded: null,
+        }
         return {
           ...event,
           decoded: contentHash !== null,

--- a/packages/ensjs/src/utils/contentHash.test.ts
+++ b/packages/ensjs/src/utils/contentHash.test.ts
@@ -99,6 +99,13 @@ describe('decodeContentHash', () => {
   it('returns null when empty bytes', () => {
     expect(decodeContentHash('0x')).toBeNull()
   })
+  it('throws for bytes with no recognisable codec (callers that want a safe read use isValidContentHash or a try/catch, e.g. decodeContentHashResult with strict: false)', () => {
+    // onchain content hash records are unvalidated - a resolver can store
+    // arbitrary bytes. decodeContentHash itself still throws here, matching
+    // its pre-existing contract; decodeContentHashResult's `strict` option
+    // relies on this to decide whether to surface or swallow the error.
+    expect(() => decodeContentHash('0xdeadbeef')).toThrow()
+  })
 })
 describe('isValidContentHash', () => {
   it('returns true for valid content hash', () => {
@@ -110,6 +117,12 @@ describe('isValidContentHash', () => {
   })
   it('returns false for invalid content hash', () => {
     expect(isValidContentHash('0x1234')).toBe(false)
+  })
+  it('returns false instead of throwing for an unset (empty) content hash', () => {
+    expect(isValidContentHash('0x')).toBe(false)
+  })
+  it('returns false instead of throwing for bytes with no recognisable codec', () => {
+    expect(isValidContentHash('0xdeadbeef')).toBe(false)
   })
 })
 describe('getProtocolType', () => {

--- a/packages/ensjs/src/utils/contentHash.ts
+++ b/packages/ensjs/src/utils/contentHash.ts
@@ -87,6 +87,14 @@ export function decodeContentHash(encoded: Hex): DecodedContentHash | null {
   if (!encoded || encoded === '0x') {
     return null
   }
+  // NB: intentionally left throwing - decodeContentHashResult()'s
+  // `strict` option relies on this propagating so it can choose whether
+  // to surface or swallow it (see getContentHash.ts and its test
+  // 'throws when strict is true and decoding fails'). Callers that want a
+  // safe, never-throwing read (isValidContentHash, the getRecords.ts
+  // multicall path, the subgraph ContenthashChanged mapper) guard for it
+  // themselves instead of this function silently downgrading every caller
+  // to non-strict.
   const decoded = decode(encoded)
   const protocolType = getDisplayCodec(encoded)
   return { protocolType, decoded }
@@ -100,8 +108,12 @@ export type IsValidContentHashErrorType = ErrorType | GetDisplayCodecErrorType
 
 export function isValidContentHash(encoded: unknown) {
   if (typeof encoded !== 'string') return false
-  const codec = getCodec(encoded)
-  return Boolean(codec && isHex(encoded))
+  try {
+    const codec = getCodec(encoded)
+    return Boolean(codec && isHex(encoded))
+  } catch {
+    return false
+  }
 }
 
 // ================================

--- a/packages/ensjs/src/utils/resolver/getContentHash.test.ts
+++ b/packages/ensjs/src/utils/resolver/getContentHash.test.ts
@@ -97,4 +97,26 @@ describe('decodeContenthashResult', () => {
       Version: viem@2.47.10]
     `)
   })
+
+  // Distinct from the case above: the outer ABI decode succeeds (well-formed
+  // `bytes` return data), but the codec inside those bytes is unrecognised.
+  // This exercises decodeContentHash's own throw, propagated through
+  // decodeContentHashResult - not decodeFunctionResult's.
+  it('returns null when strict is false and the content hash codec is unrecognised', () => {
+    const encoded = encodeFunctionResult({
+      abi: publicResolverContenthashSnippet,
+      functionName: 'contenthash',
+      result: '0xdeadbeef',
+    })
+    expect(decodeContentHashResult(encoded, { strict: false })).toBeNull()
+  })
+
+  it('throws when strict is true and the content hash codec is unrecognised', () => {
+    const encoded = encodeFunctionResult({
+      abi: publicResolverContenthashSnippet,
+      functionName: 'contenthash',
+      result: '0xdeadbeef',
+    })
+    expect(() => decodeContentHashResult(encoded, { strict: true })).toThrow()
+  })
 })


### PR DESCRIPTION
## What it says on the box

`decodeContentHash`/`isValidContentHash` (`src/utils/contentHash.ts`) call `@ensdomains/content-hash`'s `decode()`/`getCodec()` with no error handling. Those throw for any hex bytes the library doesn't recognise as a known codec — which is completely legal on-chain: `ContentHashResolver.sol` stores whatever bytes the owner supplies with zero validation, so a resolver record can be anything.

Two consumers call these unguarded and crash instead of degrading gracefully:
- `getRecords()`'s multicall path (`src/actions/public/resolver/getRecords.ts`) — its sibling `coins` branch 20 lines above already has a `try/catch` with the comment *"Don't panic if coming across an unknown coinType"*; the `contentHash` branch never got the same treatment.
- The subgraph `ContenthashChanged` event mapper (`src/actions/subgraph/utils.ts`) — same gap.

## The vacuous test that hid this

```ts
it('returns false for invalid content hash', () => {
  expect(isValidContentHash('0x1234')).toBe(false)
})
```

`'0x1234'` is a lucky draw — it happens to decode to an `undefined` codec without throwing. Real behavior with the pinned `@ensdomains/content-hash@3.1.0-rc.1`:

```
isValidContentHash('0x1234')       [existing 'invalid' test case] -> false
isValidContentHash('0x')           [an UNSET contenthash record]  -> THREW ReferenceError: read is not defined
isValidContentHash('0xdeadbeef')                                  -> THREW ReferenceError: read is not defined
```

12/200 random 4-byte hex values threw in a quick sweep.

## Fix

- `isValidContentHash` gets a `try/catch`, returning `false` on any decode failure — it's a pure predicate, there's no reason for it to ever throw.
- `getRecords.ts`'s `contentHash` branch gets a `try/catch` mirroring its sibling `coins` branch exactly.
- `subgraph/utils.ts`'s `ContenthashChanged` mapper gets a `try/catch` around its `decodeContentHash` call.
- `decodeContentHash` itself is **left throwing on purpose** — see below, this is the one non-obvious part of the fix.

### Why `decodeContentHash` still throws

`decodeContentHashResult` (`src/utils/resolver/getContentHash.ts`) already wraps `decodeContentHash` in its own `try/catch` and has an existing, tested `strict` contract:

```ts
it('throws when strict is true and decoding fails', () => { ... })
```

An earlier version of this fix made `decodeContentHash` swallow the error internally and always return `null`. That silently broke `strict: true` for this specific failure class — the outer wrapper's catch never fires because nothing is thrown to catch, so `strict: true` stops throwing for malformed codec bytes while still throwing for malformed ABI-size bytes (an inconsistent, undocumented narrowing of the documented "Whether or not to throw decoding errors" option). I caught this myself before committing anything, added two tests that pin the correct contract (`getContentHash.test.ts`), and confirmed they fail against the swallowing version and pass against the final one.

## Receipts

Full pure-logic suite (this repo's `vitest.config.ts` gates *all* projects, including logic-only ones, behind a docker-compose devnet via a root `globalSetup` — unavailable in my sandbox due to a `docker compose` version mismatch unrelated to this change; ran with a local-only config scoped to the same `pureLogicTests` glob the real config already documents as devnet-independent, not committed):

```
$ npx vitest run --config <pureLogicTests-only, no globalSetup>
 Test Files  28 passed (28)
      Tests  240 passed (240)
```

Genuine red-before/green-after, not just described — stashed the fix, reran:
```
FAIL src/utils/contentHash.test.ts > isValidContentHash > returns false instead of throwing for an unset (empty) content hash
FAIL src/utils/contentHash.test.ts > isValidContentHash > returns false instead of throwing for bytes with no recognisable codec
 Tests  3 failed | 28 passed (31)   [exact predicted ReferenceError, same file]
```
Restored → 31/31.

Also proved the two new `getContentHash.test.ts` strict-contract tests actually catch the regression I almost shipped — temporarily reapplied the swallowing version of `decodeContentHash`, confirmed both new tests fail with the exact predicted assertion, restored the correct fix, reran clean.

```
$ npx tsc --noEmit
(clean, exit 0)

$ npx biome check <touched files>
Found 5 warnings (identical on unmodified baseline — confirmed via git stash — zero new)
```

`getRecords.test.ts` needs the live devnet (multicall against a real resolver) so I couldn't run it in this sandbox; the change there is a narrow `try/catch` around existing logic with no behavior change on the success path, mirroring an already-tested sibling branch in the same function.

## Verification note

Codex CLI stalled with no output on two attempts in this environment (heavy concurrent sibling-process load); I killed each cleanly (confirmed no lingering process both times) and did the adversarial pass myself instead — which is what surfaced the `strict: true` regression above. Documenting that honestly rather than claiming a Codex pass that didn't happen.
