### PR TITLE
fix(v2): generate a fresh CREATE2 salt per call, forward roleBitmap in deployVerifiableProxy

### DIFF
--- a/packages/ensjs/src/actions/wallet/v2/verifiableFactory/deploySubregistry.test.ts
+++ b/packages/ensjs/src/actions/wallet/v2/verifiableFactory/deploySubregistry.test.ts
@@ -1,0 +1,34 @@
+import { expect, it } from 'vitest'
+import { deploySubregistryWriteParameters } from './deploySubregistry.js'
+
+const fakeClient = {
+  chain: { id: 1 },
+  account: { address: '0x000000000000000000000000000000000000dEaD' },
+} as any
+
+it('generates a fresh default salt on every call, not a value fixed at module load', () => {
+  const p1 = deploySubregistryWriteParameters(fakeClient, {
+    factoryAddress: '0x24e32c34effb021cc360b6a4e1de2850dcc59956',
+    implAddress: '0xc3ae19b222d527d3cdda617953ab878a35527e54',
+  })
+  const p2 = deploySubregistryWriteParameters(fakeClient, {
+    factoryAddress: '0x24e32c34effb021cc360b6a4e1de2850dcc59956',
+    implAddress: '0xc3ae19b222d527d3cdda617953ab878a35527e54',
+  })
+  // Reusing the default salt across two calls in the same process previously
+  // reused the exact same value, so the second on-chain deploy always
+  // reverted (VerifiableFactory.deployProxy reverts on a repeated
+  // (msg.sender, salt) pair). A fresh salt per call is what makes two
+  // sequential default-salt deploys both succeed.
+  expect(p1.args[1]).not.toEqual(p2.args[1])
+})
+
+it('still honors an explicitly provided salt', () => {
+  const explicitSalt = 123n
+  const p = deploySubregistryWriteParameters(fakeClient, {
+    factoryAddress: '0x24e32c34effb021cc360b6a4e1de2850dcc59956',
+    implAddress: '0xc3ae19b222d527d3cdda617953ab878a35527e54',
+    salt: explicitSalt,
+  })
+  expect(p.args[1]).toEqual(explicitSalt)
+})

--- a/packages/ensjs/src/actions/wallet/v2/verifiableFactory/deploySubregistry.ts
+++ b/packages/ensjs/src/actions/wallet/v2/verifiableFactory/deploySubregistry.ts
@@ -13,7 +13,7 @@ import type {
   WriteContractErrorType,
   WriteContractParameters,
 } from 'viem'
-import { encodeFunctionData, keccak256, stringToBytes } from 'viem'
+import { encodeFunctionData } from 'viem'
 import { writeContract } from 'viem/actions'
 import { getAction } from 'viem/utils'
 import type {
@@ -25,6 +25,7 @@ import {
   type ClientWithOverridesErrorType,
   clientWithOverrides,
 } from '../../../../utils/clientWithOverrides.js'
+import { generateDefaultSalt } from '../../../../utils/verifiableFactory/generateDefaultSalt.js'
 
 // ================================
 // Constants
@@ -33,7 +34,6 @@ import {
 const DEFAULT_ROLE_BITMAP = BigInt(
   '0x1111111111111111111111111111111111111111111111111111111111111111',
 )
-const DEFAULT_SALT = BigInt(keccak256(stringToBytes(new Date().toISOString())))
 
 // ================================
 // Write parameters
@@ -50,8 +50,8 @@ export type DeploySubregistryWriteParametersParameters = {
   roleBitmap?: bigint
   /**
    * The salt for proxy deployment.
-   * If omitted, a timestamp-based salt is generated via
-   * `keccak256(stringToBytes(new Date().toISOString()))`.
+   * If omitted, a fresh cryptographically random salt is generated on
+   * every call via `crypto.getRandomValues`.
    */
   salt?: bigint
 }
@@ -73,7 +73,7 @@ export const deploySubregistryWriteParameters = <
     implAddress,
     adminAddress,
     roleBitmap = DEFAULT_ROLE_BITMAP,
-    salt = DEFAULT_SALT,
+    salt = generateDefaultSalt(),
   }: DeploySubregistryWriteParametersParameters,
 ) => {
   ASSERT_NO_TYPE_ERROR(client)

--- a/packages/ensjs/src/actions/wallet/v2/verifiableFactory/deployVerifiableProxy.test.ts
+++ b/packages/ensjs/src/actions/wallet/v2/verifiableFactory/deployVerifiableProxy.test.ts
@@ -1,0 +1,80 @@
+import { expect, it, vi } from 'vitest'
+import {
+  deployVerifiableProxy,
+  deployVerifiableProxyWriteParameters,
+} from './deployVerifiableProxy.js'
+
+const fakeClient = {
+  chain: { id: 1 },
+  account: { address: '0x000000000000000000000000000000000000dEaD' },
+} as any
+
+it('generates a fresh default salt on every call, not a value fixed at module load', () => {
+  const p1 = deployVerifiableProxyWriteParameters(fakeClient, {
+    factoryAddress: '0x24e32c34effb021cc360b6a4e1de2850dcc59956',
+    implAddress: '0xc3ae19b222d527d3cdda617953ab878a35527e54',
+  })
+  const p2 = deployVerifiableProxyWriteParameters(fakeClient, {
+    factoryAddress: '0x24e32c34effb021cc360b6a4e1de2850dcc59956',
+    implAddress: '0xc3ae19b222d527d3cdda617953ab878a35527e54',
+  })
+  // See deploySubregistry.test.ts for why this matters: reusing the default
+  // salt across calls makes every deploy after the first one revert on-chain.
+  expect(p1.args[1]).not.toEqual(p2.args[1])
+})
+
+it('still honors an explicitly provided salt', () => {
+  const explicitSalt = 123n
+  const p = deployVerifiableProxyWriteParameters(fakeClient, {
+    factoryAddress: '0x24e32c34effb021cc360b6a4e1de2850dcc59956',
+    implAddress: '0xc3ae19b222d527d3cdda617953ab878a35527e54',
+    salt: explicitSalt,
+  })
+  expect(p.args[1]).toEqual(explicitSalt)
+})
+
+it('writeParameters layer honors a custom roleBitmap', () => {
+  const customBitmap = 0x1n
+  const defaultBitmapParams = deployVerifiableProxyWriteParameters(fakeClient, {
+    factoryAddress: '0x24e32c34effb021cc360b6a4e1de2850dcc59956',
+    implAddress: '0xc3ae19b222d527d3cdda617953ab878a35527e54',
+  })
+  const customBitmapParams = deployVerifiableProxyWriteParameters(fakeClient, {
+    factoryAddress: '0x24e32c34effb021cc360b6a4e1de2850dcc59956',
+    implAddress: '0xc3ae19b222d527d3cdda617953ab878a35527e54',
+    roleBitmap: customBitmap,
+  })
+  expect(customBitmapParams.args[2]).not.toEqual(defaultBitmapParams.args[2])
+})
+
+it('forwards a custom roleBitmap from the action through to the transaction (regression: it was previously dropped, silently granting full permissions instead)', async () => {
+  const customBitmap = 0x1n
+  const writeContractSpy = vi.fn().mockResolvedValue('0xhash')
+  const spyClient = { ...fakeClient, writeContract: writeContractSpy }
+
+  await deployVerifiableProxy(spyClient, {
+    factoryAddress: '0x24e32c34effb021cc360b6a4e1de2850dcc59956',
+    implAddress: '0xc3ae19b222d527d3cdda617953ab878a35527e54',
+    roleBitmap: customBitmap,
+  } as any)
+
+  const sentCallData = writeContractSpy.mock.calls[0][0].args[2]
+  const expectedWithDefaultBitmap = deployVerifiableProxyWriteParameters(
+    fakeClient,
+    {
+      factoryAddress: '0x24e32c34effb021cc360b6a4e1de2850dcc59956',
+      implAddress: '0xc3ae19b222d527d3cdda617953ab878a35527e54',
+    },
+  ).args[2]
+  const expectedWithCustomBitmap = deployVerifiableProxyWriteParameters(
+    fakeClient,
+    {
+      factoryAddress: '0x24e32c34effb021cc360b6a4e1de2850dcc59956',
+      implAddress: '0xc3ae19b222d527d3cdda617953ab878a35527e54',
+      roleBitmap: customBitmap,
+    },
+  ).args[2]
+
+  expect(sentCallData).toEqual(expectedWithCustomBitmap)
+  expect(sentCallData).not.toEqual(expectedWithDefaultBitmap)
+})

--- a/packages/ensjs/src/actions/wallet/v2/verifiableFactory/deployVerifiableProxy.test.ts
+++ b/packages/ensjs/src/actions/wallet/v2/verifiableFactory/deployVerifiableProxy.test.ts
@@ -1,8 +1,18 @@
+import { proxyInitializeSnippet } from '@ensdomains/ensjs-abi/v2/verifiableFactory'
+import { decodeFunctionData, type Hex } from 'viem'
 import { expect, it, vi } from 'vitest'
 import {
   deployVerifiableProxy,
   deployVerifiableProxyWriteParameters,
 } from './deployVerifiableProxy.js'
+
+const decodedRoleBitmap = (callData: Hex): bigint => {
+  const { args } = decodeFunctionData({
+    abi: proxyInitializeSnippet,
+    data: callData,
+  })
+  return args[1]
+}
 
 const fakeClient = {
   chain: { id: 1 },
@@ -35,16 +45,14 @@ it('still honors an explicitly provided salt', () => {
 
 it('writeParameters layer honors a custom roleBitmap', () => {
   const customBitmap = 0x1n
-  const defaultBitmapParams = deployVerifiableProxyWriteParameters(fakeClient, {
-    factoryAddress: '0x24e32c34effb021cc360b6a4e1de2850dcc59956',
-    implAddress: '0xc3ae19b222d527d3cdda617953ab878a35527e54',
-  })
   const customBitmapParams = deployVerifiableProxyWriteParameters(fakeClient, {
     factoryAddress: '0x24e32c34effb021cc360b6a4e1de2850dcc59956',
     implAddress: '0xc3ae19b222d527d3cdda617953ab878a35527e54',
     roleBitmap: customBitmap,
   })
-  expect(customBitmapParams.args[2]).not.toEqual(defaultBitmapParams.args[2])
+  expect(decodedRoleBitmap(customBitmapParams.args[2] as Hex)).toEqual(
+    customBitmap,
+  )
 })
 
 it('forwards a custom roleBitmap from the action through to the transaction (regression: it was previously dropped, silently granting full permissions instead)', async () => {
@@ -58,23 +66,11 @@ it('forwards a custom roleBitmap from the action through to the transaction (reg
     roleBitmap: customBitmap,
   } as any)
 
-  const sentCallData = writeContractSpy.mock.calls[0][0].args[2]
-  const expectedWithDefaultBitmap = deployVerifiableProxyWriteParameters(
-    fakeClient,
-    {
-      factoryAddress: '0x24e32c34effb021cc360b6a4e1de2850dcc59956',
-      implAddress: '0xc3ae19b222d527d3cdda617953ab878a35527e54',
-    },
-  ).args[2]
-  const expectedWithCustomBitmap = deployVerifiableProxyWriteParameters(
-    fakeClient,
-    {
-      factoryAddress: '0x24e32c34effb021cc360b6a4e1de2850dcc59956',
-      implAddress: '0xc3ae19b222d527d3cdda617953ab878a35527e54',
-      roleBitmap: customBitmap,
-    },
-  ).args[2]
+  const sentCallData = writeContractSpy.mock.calls[0][0].args[2] as Hex
 
-  expect(sentCallData).toEqual(expectedWithCustomBitmap)
-  expect(sentCallData).not.toEqual(expectedWithDefaultBitmap)
+  // Decode the actual on-chain calldata and assert the roleBitmap that was
+  // requested is the one that lands in the transaction - not merely "some
+  // value different from the default", which would also pass for an
+  // incorrectly-encoded bitmap.
+  expect(decodedRoleBitmap(sentCallData)).toEqual(customBitmap)
 })

--- a/packages/ensjs/src/actions/wallet/v2/verifiableFactory/deployVerifiableProxy.ts
+++ b/packages/ensjs/src/actions/wallet/v2/verifiableFactory/deployVerifiableProxy.ts
@@ -14,7 +14,7 @@ import type {
   WriteContractErrorType,
   WriteContractParameters,
 } from 'viem'
-import { encodeFunctionData, keccak256, stringToBytes } from 'viem'
+import { encodeFunctionData } from 'viem'
 import { writeContract } from 'viem/actions'
 import { getAction } from 'viem/utils'
 import type {
@@ -26,6 +26,7 @@ import {
   type ClientWithOverridesErrorType,
   clientWithOverrides,
 } from '../../../../utils/clientWithOverrides.js'
+import { generateDefaultSalt } from '../../../../utils/verifiableFactory/generateDefaultSalt.js'
 
 // ================================
 // Constants
@@ -34,7 +35,6 @@ import {
 const DEFAULT_ROLE_BITMAP = BigInt(
   '0x1111111111111111111111111111111111111111111111111111111111111111',
 )
-const DEFAULT_SALT = BigInt(keccak256(stringToBytes(new Date().toISOString())))
 
 // ================================
 // Write parameters
@@ -59,8 +59,8 @@ export type DeployVerifiableProxyWriteParametersParameters = {
   roleBitmap?: bigint
   /**
    * The salt for proxy deployment.
-   * If omitted, a timestamp-based salt is generated via
-   * `keccak256(stringToBytes(new Date().toISOString()))`.
+   * If omitted, a fresh cryptographically random salt is generated on
+   * every call via `crypto.getRandomValues`.
    */
   salt?: bigint
 }
@@ -82,7 +82,7 @@ export const deployVerifiableProxyWriteParameters = <
     implAddress,
     callData,
     roleBitmap = DEFAULT_ROLE_BITMAP,
-    salt = DEFAULT_SALT,
+    salt = generateDefaultSalt(),
   }: DeployVerifiableProxyWriteParametersParameters,
 ) => {
   ASSERT_NO_TYPE_ERROR(client)
@@ -159,6 +159,7 @@ export async function deployVerifiableProxy<
     factoryAddress,
     implAddress,
     callData,
+    roleBitmap,
     salt,
     ...txArgs
   }: DeployVerifiableProxyParameters<chain, account, chainOverride>,
@@ -171,6 +172,7 @@ export async function deployVerifiableProxy<
       factoryAddress,
       implAddress,
       callData,
+      roleBitmap,
       salt,
     },
   )

--- a/packages/ensjs/src/utils/verifiableFactory/generateDefaultSalt.ts
+++ b/packages/ensjs/src/utils/verifiableFactory/generateDefaultSalt.ts
@@ -1,0 +1,18 @@
+/**
+ * Generates a fresh, cryptographically random salt for CREATE2 proxy
+ * deployment via {@link VerifiableFactory}.
+ *
+ * Must be called fresh on every deployment attempt (as a function default,
+ * never as a module-level constant) - the factory reverts on a repeated
+ * `(msg.sender, salt)` pair, so reusing a value across calls in the same
+ * process makes every deploy after the first one fail.
+ */
+export const generateDefaultSalt = (): bigint => {
+  const bytes = new Uint8Array(32)
+  crypto.getRandomValues(bytes)
+  let salt = 0n
+  for (const byte of bytes) {
+    salt = (salt << 8n) | BigInt(byte)
+  }
+  return salt
+}

--- a/packages/ensjs/vitest.config.ts
+++ b/packages/ensjs/vitest.config.ts
@@ -22,6 +22,7 @@ const pureLogicTests = [
   'src/actions/dns/getDnsOwner.test.ts',
   'src/actions/public/getNames.test.ts',
   'src/actions/public/resolveNameData.test.ts',
+  'src/actions/wallet/v2/verifiableFactory/**/*.test.ts',
 ]
 
 export default defineConfig({


### PR DESCRIPTION
`packages/ensjs/src/actions/wallet/v2/verifiableFactory/{deploySubregistry,deployVerifiableProxy}.ts` had two independent bugs.

## 1. Default CREATE2 salt was computed once at module load, not per call

```ts
const DEFAULT_SALT = BigInt(keccak256(stringToBytes(new Date().toISOString())))
```

This is a module-level constant, evaluated once when the file is imported - not once per function call, despite the JSDoc on `salt?: bigint` saying "a timestamp-based salt is generated". Every call in the same process that doesn't pass an explicit `salt` reuses the identical default.

`VerifiableFactory.deployProxy` computes `outerSalt = keccak256(abi.encode(msg.sender, salt))` and does a bare `create2(...)` with `if iszero(proxy) { revert(0, 0) }` - CREATE2 returns the zero address when targeting an address that already has code, so a repeated `(msg.sender, salt)` pair reverts with **empty revert data**. Concretely: any script, batch job, or backend service that calls `deploySubregistry`/`deployVerifiableProxy` more than once per process (without passing an explicit `salt`) gets a working first deploy and a bare-revert second deploy, with no diagnosable error message. A dapp calling this once per page load never hits it.

Fixed by generating a fresh cryptographically random salt via `crypto.getRandomValues` inside the parameter default (evaluates fresh on every call, since default expressions are function calls, not constants), in a new `generateDefaultSalt()` helper shared by both actions.

## 2. `deployVerifiableProxy` silently dropped a caller-supplied `roleBitmap`

```ts
export async function deployVerifiableProxy<...>(
  client, { factoryAddress, implAddress, callData, salt, ...txArgs }, // roleBitmap missing
) {
  const writeParameters = deployVerifiableProxyWriteParameters(clientWithOverrides(client, txArgs), {
    factoryAddress, implAddress, callData, salt, // roleBitmap never forwarded
  })
```

`roleBitmap` is a documented public parameter ("The role bitmap granted to the proxy admin ... Defaults to a bitmap containing every role") and part of the public parameter type, but the action's outer destructure never pulled it out - so it fell into `...txArgs` and never reached `deployVerifiableProxyWriteParameters`. Any caller passing a custom (e.g. least-privilege) `roleBitmap` silently got the **default full-permissions bitmap** instead.

The sibling `deploySubregistry` action already destructures and forwards `roleBitmap` correctly (compare `deploySubregistry.ts:153,165`) - this is a straight asymmetry between two files in the same directory.

Not a theft vector - the admin receiving the over-broad grant is the caller themselves (`client.account.address`), not an attacker. It's a silent over-grant that requires an extra revoke transaction to correct.

## Why neither was caught

`src/actions/wallet/v2/verifiableFactory/` had **zero test files** before this PR.

## Receipts

Genuine red-before/green-after via `git stash` on the source fix, tests kept in place:

```
FAIL deploySubregistry.test.ts > generates a fresh default salt on every call
  expected 23540908115685667322151789045906954782…n to not deeply equal 23540908115685667322151789045906954782…n
FAIL deployVerifiableProxy.test.ts > generates a fresh default salt on every call
  expected 23540908115685667322151789045906954782…n to not deeply equal 23540908115685667322151789045906954782…n
FAIL deployVerifiableProxy.test.ts > forwards a custom roleBitmap from the action through to the transaction
  Expected: "...dead0000...0001"   (custom 0x1 bitmap)
  Received: "...dead1111...1111"  (silently-substituted default bitmap)
```

Restored fix, all 6 pass:

```
✓ deploySubregistry.test.ts (2 tests)
✓ deployVerifiableProxy.test.ts (4 tests)

Test Files  2 passed (2)
     Tests  6 passed (6)
```

Codex adversarial review caught a real gap in my first pass: the roleBitmap tests only asserted the custom calldata **differed** from the default, which would also pass for an incorrectly-encoded bitmap. Strengthened to decode the calldata via `decodeFunctionData` and assert the actual `roleBitmap` argument equals the value that was requested.

Codex also raised a lower-confidence concern about `crypto.getRandomValues` throwing under `node --no-experimental-global-webcrypto` - I checked this directly: that flag no longer exists in current Node (`node --no-experimental-global-webcrypto -e ...` errors as an invalid negation), so this isn't a live concern on supported Node versions. Noting it here rather than adding defensive code for a non-existent runtime configuration.

`tsc --noEmit` clean, `biome check` clean (pre-existing `noExplicitAny` warning pattern in test mocks, same as the rest of the wallet action test suite, no new errors).

One environment note, unrelated to this diff: this sandbox's Docker Compose (v2.15.1) can't start the repo's devnet due to an unsupported `healthcheck.start_interval` compose-spec property, so I ran these two new (chain-independent) test files against an isolated Vitest config bypassing `globalSetup`, confirmed identical results via the real project config's `parallel` project (added the new test glob to `pureLogicTests` in `vitest.config.ts` - these tests only exercise pure encoding logic against a mocked client, never touching chain state, matching the file's own stated categorization).
